### PR TITLE
Zasady odwołań do WCAG, normy i ustawy

### DIFF
--- a/documentation/docs/o-sieci/praca-nad-dokumentami/odwolania-do-ustawy.md
+++ b/documentation/docs/o-sieci/praca-nad-dokumentami/odwolania-do-ustawy.md
@@ -1,0 +1,202 @@
+---
+id: odwolania-do-ustawy
+title: Zasady odwoływania się do ustawy o dostępności cyfrowej, normy EN 301 549 oraz WCAG
+description: Ujednolicenie i uporządkowanie sposobu odwoływania się w materiałach Sieci Dostępności Cyfrowej ustawy o dostępności cyfrowej, normy EN 301 549 oraz WCAG
+sidebar_label: Odwołania do ustawy...
+sidebar_position: 2
+keywords: [dokumenty Sieci, formy dokumentów, zasady formowania dokumentów]
+opracowanie: Stefan Wajda
+data_zgloszenia: 23 grudnia 2025 r.
+ostatnia_aktualizacja: 23 grudnia 2025 r.
+wersja_robocza: true
+---
+
+ 
+**w materiałach Sieci Dostępności Cyfrowej**
+
+## 1. Cel dokumentu
+
+Celem niniejszego dokumentu jest ujednolicenie i uporządkowanie sposobu odwoływania się w materiałach Sieci Dostępności Cyfrowej do:
+- ustawy o dostępności cyfrowej stron internetowych i aplikacji mobilnych podmiotów publicznych,
+- normy europejskiej EN 301 549,
+- Wytycznych dla dostępności treści internetowych (WCAG).
+
+Dokument ma charakter wewnętrzny i służy:
+- zapewnieniu spójności merytorycznej i terminologicznej,
+- unikaniu błędnych uproszczeń interpretacyjnych,
+- wspieraniu zespołów autorskich w poprawnym formułowaniu zaleceń, standardów i materiałów edukacyjnych.
+
+---
+
+## 2. Ustawa o dostępności cyfrowej jako nadrzędny punkt odniesienia
+
+Podstawowym i nadrzędnym punktem odniesienia dla podmiotów publicznych w Polsce jest **ustawa o dostępności cyfrowej stron internetowych i aplikacji mobilnych podmiotów publicznych**.
+
+Ustawa:
+- ustanawia **obowiązek prawny** zapewnienia dostępności cyfrowej,
+- definiuje dostępność cyfrową poprzez funkcjonalność, kompatybilność, postrzegalność i zrozumiałość,
+- określa mechanizm uznania spełnienia wymagań dostępności.
+
+W materiałach Sieci do ustawy należy odwoływać się zawsze wtedy, gdy mowa jest o:
+- obowiązkach podmiotów publicznych,
+- odpowiedzialności, nadzorze i kontroli,
+- deklaracji dostępności,
+- skargach i wnioskach,
+- terminach oraz konsekwencjach prawnych.
+
+---
+
+## 3. Rola normy EN 301 549 w systemie prawnym
+
+### 3.1. EN 301 549 jako standard techniczny przywołany w ustawie
+
+Ustawa nie przywołuje wprost Wytycznych WCAG jako standardu technicznego.  
+Zgodnie z art. 5 ust. 3 ustawy, spełnienie wymagań dostępności uznaje się za zapewnione, jeżeli podmiot publiczny uwzględnia wymagania określone w normie **EN 301 549**.
+
+Oznacza to, że:
+- formalnym standardem technicznym w systemie prawnym jest **norma europejska EN 301 549**,
+- norma ta stanowi pomost między przepisami prawa a wymaganiami technicznymi,
+- WCAG nie funkcjonuje w ustawie jako samodzielne źródło obowiązków prawnych.
+
+### 3.2. Celowe nieprzywołanie WCAG w ustawie
+
+Zgodnie z wyjaśnieniami Ministerstwa Cyfryzacji, brak bezpośredniego wskazania WCAG w ustawie był działaniem celowym.  
+Intencją ustawodawcy było:
+- oparcie regulacji na neutralnej technologicznie normie europejskiej,
+- zapewnienie spójności z prawem Unii Europejskiej,
+- umożliwienie aktualizacji wymagań technicznych bez konieczności nowelizacji ustawy.
+
+---
+
+## 4. Relacja między EN 301 549 a WCAG
+
+Norma EN 301 549:
+- implementuje kryteria sukcesu WCAG 2.1 na poziomach A i AA,
+- osadza je w kontekście normatywnym Unii Europejskiej,
+- rozszerza zakres wymagań poza same treści WWW.
+
+WCAG stanowi zatem:
+- **źródło merytoryczne i techniczne** wymagań dostępności,
+- komponent normy EN 301 549 w odniesieniu do treści internetowych,
+- punkt odniesienia dla interpretacji szczegółowych kryteriów sukcesu.
+
+Jednocześnie **to EN 301 549**, a nie WCAG, jest standardem technicznym przywołanym przez ustawę.
+
+---
+
+## 5. Dlaczego w materiałach Sieci właściwsze jest odwoływanie się do EN 301 549
+
+### 5.1. Zakres normy
+
+Norma EN 301 549 ma zakres szerszy niż same Wytyczne WCAG.  
+Obejmuje ona m.in.:
+- strony internetowe i aplikacje webowe,
+- natywne aplikacje mobilne,
+- inne rodzaje oprogramowania,
+- dokumenty cyfrowe,
+- interfejsy użytkownika systemów informatycznych.
+
+Zapewnia to spójne i kompleksowe podejście do dostępności cyfrowej, adekwatne do realiów funkcjonowania podmiotów publicznych.
+
+### 5.2. Odpowiednik prawny w skali UE
+
+EN 301 549 jest oficjalną normą europejską, stosowaną w całej Unii Europejskiej.  
+Stanowi ona wspólny punkt odniesienia m.in. w kontekście **European Accessibility Act (EAA)**.
+
+Odwoływanie się do normy:
+- ułatwia zgodność z regulacjami unijnymi,
+- wspiera interoperacyjność interpretacyjną,
+- wzmacnia odporność dokumentów Sieci na zmiany legislacyjne.
+
+### 5.3. Spójność regulacyjna
+
+Stosowanie EN 301 549 jako podstawowego standardu technicznego:
+- zapewnia zgodność z ustawą krajową,
+- przygotowuje podmioty publiczne na przyszłe wymogi UE,
+- pozwala traktować normę jako „jedno źródło prawdy” dla dostępności cyfrowej.
+
+### 5.4. Poziom szczegółowości technicznej
+
+Norma EN 301 549 dostarcza:
+- jednoznacznych kryteriów oceny,
+- podstaw do audytów i testów dostępności,
+- wspólnego języka dla zamawiających, wykonawców i audytorów.
+
+Umożliwia to praktyczne przełożenie obowiązków prawnych na wymagania możliwe do weryfikacji.
+
+---
+
+## 6. Intencjonalne przywoływanie WCAG jako podwyższonego poziomu wymagań
+
+### 6.1. Minimalne wymagania a podwyższone standardy
+
+EN 301 549 określa **minimalne wymagania**, których spełnienie jest konieczne dla zapewnienia zgodności z prawem.
+
+Jednocześnie podmioty publiczne:
+- mogą ustanawiać **wymagania wykraczające poza minimum**,
+- pod warunkiem ich proporcjonalności i uzasadnienia,
+- w szczególności w kontekście jakości usług publicznych.
+
+### 6.2. Rola WCAG w podwyższaniu wymagań
+
+W tym kontekście **WCAG może być świadomie i celowo przywoływane** jako źródło:
+- dodatkowych wymagań jakościowych,
+- dobrych praktyk projektowych,
+- wybranych kryteriów sukcesu na poziomie AAA.
+
+Odwołania te:
+- nie oznaczają obowiązku spełnienia wszystkich kryteriów poziomu AAA,
+- dotyczą wyłącznie wskazanych, uzasadnionych kryteriów,
+- mają charakter projektowy i jakościowy, a nie normatywny.
+
+### 6.3. Zamówienia publiczne
+
+W dokumentacji zamówień publicznych:
+- **EN 301 549** powinna być wskazywana jako minimalny standard zgodności z prawem,
+- **WCAG** może być przywoływana:
+  - w odniesieniu do wybranych kryteriów sukcesu,
+  - jako element podwyższonych wymagań jakościowych,
+  - z wyraźnym rozróżnieniem od obowiązkowego minimum.
+
+Przykładowa formuła:
+> „Zamawiający wymaga spełnienia normy EN 301 549. Dodatkowo, w celu podniesienia jakości dostępności, Zamawiający określa wymagania odnoszące się do wybranych kryteriów sukcesu WCAG 2.1 na poziomie AAA.”
+
+---
+
+## 7. Zasady stosowania odwołań w materiałach Sieci
+
+### 7.1. Odwołania do ustawy
+Stosować w kontekście obowiązków, odpowiedzialności i mechanizmów prawnych.
+
+### 7.2. Odwołania do EN 301 549
+Stosować jako podstawowy punkt odniesienia dla:
+- wymagań technicznych,
+- audytów,
+- oceny zgodności,
+- zamówień publicznych.
+
+### 7.3. Odwołania do WCAG
+Stosować:
+- w materiałach edukacyjnych i szkoleniowych,
+- przy omawianiu kryteriów sukcesu i technik,
+- przy definiowaniu podwyższonych wymagań jakościowych,
+- zawsze z wyraźnym wskazaniem relacji do EN 301 549.
+
+---
+
+## 8. Zasada nadrzędna Sieci Dostępności Cyfrowej
+
+W materiałach Sieci przyjmuje się następującą zasadę:
+
+> **Obowiązek wynika z ustawy.  
+> Standard techniczny określa norma EN 301 549.  
+> WCAG stanowi źródło szczegółowych kryteriów technicznych, w tym także dla podwyższonych wymagań jakościowych.**
+
+Zasada ta powinna być stosowana konsekwentnie we wszystkich opracowaniach Sieci, z uwzględnieniem ich celu, odbiorców i charakteru.
+
+---
+
+## 9. Postanowienia końcowe
+
+Niniejszy dokument stanowi podstawę interpretacyjną dla prac Sieci Dostępności Cyfrowej.  
+Może być aktualizowany w przypadku zmian legislacyjnych, normatywnych lub organizacyjnych.


### PR DESCRIPTION
Projekt ustalenia zasad dotyczących odwołań do WCAG, EN 301 549 i ustawy o dostępności cyfrowej 

[Zobacz podgląd dokumentu](https://deploy-preview-35--siec-dostepnosci-cyfrowej.netlify.app/docs/o-sieci/praca-nad-dokumentami/odwolania-do-ustawy)