### PR TITLE
Dodanie zalecenia Procedura kontroli dostępności przed publikacją treści

### DIFF
--- a/documentation/docs/komunikacja/kontrola-przed-publikacja/zalecenie-kontrola-przed-publikacka.md
+++ b/documentation/docs/komunikacja/kontrola-przed-publikacja/zalecenie-kontrola-przed-publikacka.md
@@ -1,12 +1,13 @@
 ---
-id: procedura-kontroli-dost-pno-ci-przed-publikacj-tresci
+id: procedura-kontroli-dostepnosci-przed-publikacja-tresci
 title: Procedura kontroli dostępności przed publikacją treści
-description: W wielu organizacjach treści trafiają do publikacji bez formalnego momentu sprawdzenia ich dostępności. Powstałe w ten sposób bariery trafiają do opublikowan...
-sidebar_label: Procedura kontroli dostępności przed publikacją treści
-sidebar_position: 999
-typ: zalecenie
-wymiar: Komunikacja
+description: W wielu organizacjach treści trafiają do publikacji bez formalnego momentu sprawdzenia ich dostępności. Powstałe w ten sposób bariery trafiają do publikacji.
+sidebar_label: Zalecenie
+sidebar_position: 1
 opracowanie: Paulina Wysakowska
+data_zgloszenia: 30 maja 2026 r.
+ostatnia_aktualizacja: 30 maja 2026 r.
+wersja_robocza: true
 ---
 
 # Zalecenie: Procedura kontroli dostępności przed publikacją treści

--- a/documentation/docs/komunikacja/kontrola-przed-publikacja/zalecenie-kontrola-przed-publikacka.md
+++ b/documentation/docs/komunikacja/kontrola-przed-publikacja/zalecenie-kontrola-przed-publikacka.md
@@ -1,0 +1,48 @@
+---
+id: procedura-kontroli-dost-pno-ci-przed-publikacj-tresci
+title: Procedura kontroli dostępności przed publikacją treści
+description: W wielu organizacjach treści trafiają do publikacji bez formalnego momentu sprawdzenia ich dostępności. Powstałe w ten sposób bariery trafiają do opublikowan...
+sidebar_label: Procedura kontroli dostępności przed publikacją treści
+sidebar_position: 999
+typ: zalecenie
+wymiar: Komunikacja
+opracowanie: Paulina Wysakowska
+---
+
+# Zalecenie: Procedura kontroli dostępności przed publikacją treści
+
+## 1. Zalecenie
+Organizacja wprowadza obowiązkowy etap sprawdzenia dostępności cyfrowej treści przed ich publikacją we wszystkich kanałach komunikacji cyfrowej.
+
+## 2. Rekomendacje
+Poniższe rekomendacje wskazują sposób realizacji zalecenia w organizacjach i jednostkach o różnej wielkości oraz na różnym poziomie dojrzałości w zakresie dostępności cyfrowej.
+- Kontrola dostępności cyfrowej przed publikacją jest obowiązkowa.
+- Sprawdzeniem objęte są wszystkie treści cyfrowe przed ich publikacją, niezależnie od kanału (strona internetowa, Biuletyn Informacji Publicznej, media społecznościowe) oraz formy (strony internetowe, dokumenty, multimedia).
+- Zakres i tryb sprawdzenia różnicowane są odpowiednio do wagi oraz pilności publikowanej informacji. Treści, których publikacja nie wymaga pośpiechu, podlegają pełnemu sprawdzeniu przed udostępnieniem. Informacje, które muszą dotrzeć do odbiorców niezwłocznie, publikowane są bez wstrzymywania na czas pełnego sprawdzenia, z zapewnieniem dostępności w możliwym zakresie i jej uzupełnieniem po publikacji.
+- Sprawdzenie wykonywane jest na podstawie Listy kontrolnej dostępnego dokumentu opracowanej w ramach Sieci Dostępności Cyfrowej.
+- Kontrola jest udokumentowana raportem z kontroli przygotowanym na podstawie Listy kontrolnej dostępnego dokumentu.
+- Wykryte błędy są niezwłocznie kierowane do właściciela treści.
+- Komentarz (do rozstrzygnięcia): Na liście tematów wymiaru Komunikacja występuje podpunkt „Odpowiedzialność właściciela treści”. Czy oznacza to, że właściciel treści odpowiada za weryfikację treści i przygotowanie raportu, czy za naprawę błędów?
+- Wykryte błędy są poprawiane przed publikacją. Jeżeli ich poprawienie przed wymaganym terminem publikacji nie jest możliwe, treść udostępniana jest wraz z alternatywnym sposobem dostępu do informacji, a błąd zostaje odnotowany z terminem usunięcia i poprawiony niezwłocznie po publikacji.
+
+## 3. Uzasadnienie
+W wielu organizacjach treści trafiają do publikacji bez formalnego momentu sprawdzenia ich dostępności. Powstałe w ten sposób bariery trafiają do opublikowanych treści; część z nich ujawniają dopiero zgłoszenia użytkowników, a wiele pozostaje niezgłoszonych i nie jest naprawianych, ograniczając dostęp odbiorców do informacji.
+Ustanowienie obowiązkowego etapu sprawdzenia porządkuje proces zarządzania treściami i dokumentami cyfrowymi oraz osadza dbałość o dostępność w codziennej pracy redakcyjnej, a nie w działaniach naprawczych podejmowanych po fakcie. Dzięki temu kontrola przed publikacją:
+- ogranicza liczbę barier docierających do odbiorców usług publicznych,
+- zmniejsza koszt i pracochłonność późniejszych poprawek,
+- wspiera spełnianie wymagań dostępności cyfrowej określonych w przepisach.
+
+## 4. Podstawy prawne
+- Art. 5 ust. 1 ustawy z dnia 4 kwietnia 2019 r. o dostępności cyfrowej stron internetowych i aplikacji mobilnych podmiotów publicznych (Dz. U. 2019, poz. 848, z późn. zm.).
+
+## 5. Źródła i opracowania
+- Sieć Dostępności Cyfrowej, Opis głównych procesów zapewniania dostępności cyfrowej (proces „Zarządzanie treściami i dokumentami cyfrowymi").
+- Norma PN-EN 301 549 (wymagania dostępności produktów i usług ICT), punkty 9 i 10.
+- WCAG 2.2 – Wytyczne dla dostępności treści internetowych (tłumaczenie), https://wcag.irdpl.pl/guidelines/22/, dostęp: 30 maja 2026.
+- Sieć Dostępności Cyfrowej, Lista kontrolna dostępnego dokumentu.
+
+## 6. Historia wersji
+- Wersja 0.1 – projekt wstępny
+
+## Załączniki
+_Brak załączników._


### PR DESCRIPTION
Dodaje zalecenie „Procedura kontroli dostępności przed publikacją treści" (temat 4 wymiaru Komunikacja)

[Zobacz podgląd dokumentu](https://deploy-preview-171--siec-dostepnosci-cyfrowej.netlify.app/docs/komunikacja/kontrola-przed-publikacja/procedura-kontroli-dostepnosci-przed-publikacja-tresci)