### PR TITLE
Dodanie listy dokumentów: ATAG dla systemów CMS

### DIFF
--- a/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/_category_.json
+++ b/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Zamawianie systemów CMS",
+  "position": 5,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/lista-wymagan-atag-dla-cms-opz-swz.md
+++ b/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/lista-wymagan-atag-dla-cms-opz-swz.md
@@ -1,0 +1,340 @@
+---
+id: lista-wymagan-atag-dla-cms
+title: Lista wymagań ATAG dla systemu CMS
+sidebar_position: 1
+description: Praktyczna lista wymagań do wykorzystania w OPZ, SWZ, umowie, kryteriach oceny ofert i odbiorze systemu CMS.
+keywords: [ATAG, CMS, OPZ, SWZ, dostępność cyfrowa, zamówienia publiczne, kryteria odbioru]
+tags: [ATAG, CMS, OPZ, SWZ, zaopatrzenie, dostępność cyfrowa]
+opracowanie: Damian Żłobicki
+data_zgloszenia: 10 czerwca 2026 r.
+ostatnia_aktualizacja: 10 czerwca 2026 r.
+wersja_robocza: true
+---
+
+## Cel dokumentu
+
+Dokument zawiera praktyczną listę wymagań, które można wykorzystać przy zamawianiu systemu CMS. Lista może być użyta jako materiał pomocniczy do przygotowania opisu przedmiotu zamówienia, SWZ, umowy, kryteriów oceny ofert, scenariuszy odbioru albo audytu wdrożonego systemu.
+
+Lista nie zastępuje pełnej analizy ATAG 2.0. Jej celem jest przełożenie wymagań ATAG na język zamówienia i codziennych scenariuszy pracy redaktora.
+
+## 1. Zakres wymagań
+
+Wymagania powinny obejmować cały proces tworzenia i publikowania treści w CMS, w szczególności:
+
+- panel administracyjny,
+- edytor treści,
+- bibliotekę mediów,
+- szablony stron,
+- komponenty redakcyjne,
+- formularze administracyjne,
+- mechanizmy tworzenia formularzy publicznych,
+- podgląd treści,
+- proces zapisu, akceptacji i publikacji,
+- mechanizmy importu, eksportu i migracji treści,
+- dokumentację użytkownika,
+- szkolenia dla redaktorów i administratorów.
+
+## 2. Wymagania dotyczące dostępności panelu CMS
+
+System CMS powinien umożliwiać redaktorom, administratorom i osobom zatwierdzającym treści korzystanie z panelu administracyjnego w sposób dostępny cyfrowo.
+
+### Minimalne wymagania
+
+1. Wszystkie kluczowe funkcje panelu są dostępne z klawiatury.
+2. Fokus klawiatury jest widoczny i logiczny.
+3. Panel nie zawiera pułapek klawiaturowych.
+4. Kolejność nawigacji jest zgodna z układem i logiką interfejsu.
+5. Elementy interaktywne mają poprawne nazwy dostępne.
+6. Przyciski, linki, pola formularzy i kontrolki są rozpoznawalne dla technologii wspomagających.
+7. Formularze administracyjne mają etykiety, instrukcje i komunikaty błędów.
+8. Komunikaty statusu są przekazywane w sposób dostępny dla technologii wspomagających.
+9. Panel zachowuje poprawną strukturę nagłówków i regionów.
+10. Mechanizmy typu „przeciągnij i upuść” mają dostępną alternatywę.
+11. Czas sesji redakcyjnej nie powoduje utraty niezapisanej pracy bez ostrzeżenia albo możliwości przedłużenia sesji.
+12. Dokumentacja panelu opisuje funkcje dostępności.
+
+### Dowody odbiorowe
+
+Wykonawca powinien wykazać, że redaktor może bez użycia myszy:
+
+- zalogować się do CMS,
+- odnaleźć listę treści,
+- utworzyć nową stronę,
+- edytować istniejącą stronę,
+- dodać obraz,
+- uzupełnić tekst alternatywny,
+- zapisać wersję roboczą,
+- skorzystać z podglądu,
+- opublikować treść,
+- odczytać i naprawić komunikaty błędów.
+
+## 3. Wymagania dotyczące edytora treści
+
+Edytor treści powinien wspierać tworzenie poprawnych, semantycznych i dostępnych treści.
+
+### Minimalne wymagania
+
+1. Redaktor może tworzyć strukturę nagłówków bez ręcznego formatowania wizualnego.
+2. Redaktor może tworzyć semantyczne listy, tabele, cytaty i linki.
+3. Edytor nie generuje pustych nagłówków, pustych akapitów, nadmiarowych znaczników ani niepoprawnego HTML przy standardowym użyciu.
+4. Redaktor może określić język treści albo fragmentu treści, jeżeli CMS obsługuje treści wielojęzyczne.
+5. Redaktor może tworzyć zrozumiałe teksty linków.
+6. Edytor powinien ostrzegać przed niejasnymi tekstami linków, jeżeli CMS posiada mechanizm walidacji treści.
+7. Redaktor może sprawdzić strukturę strony przed publikacją.
+8. Podgląd treści pokazuje treść w sposób możliwie zbliżony do wersji opublikowanej.
+9. Widok podglądu nie ukrywa problemów, które wystąpią w opublikowanej treści.
+10. Edytor umożliwia poprawę błędów bez konieczności ręcznej edycji kodu HTML, chyba że ręczna edycja kodu jest świadomie przewidzianym trybem zaawansowanym.
+
+### Dowody odbiorowe
+
+Wykonawca powinien pokazać utworzenie strony zawierającej:
+
+- jeden nagłówek główny,
+- logiczną strukturę nagłówków niższych poziomów,
+- listę,
+- link o zrozumiałej treści,
+- tabelę z nagłówkami,
+- obraz informacyjny z tekstem alternatywnym,
+- obraz dekoracyjny oznaczony jako dekoracyjny,
+- treść zapisaną, sprawdzoną, poprawioną i opublikowaną.
+
+## 4. Wymagania dotyczące obrazów i mediów
+
+CMS powinien wspierać poprawne zarządzanie alternatywami dla treści nietekstowych.
+
+### Minimalne wymagania
+
+1. Przy dodawaniu obrazu CMS umożliwia wpisanie tekstu alternatywnego.
+2. CMS umożliwia oznaczenie obrazu jako dekoracyjnego.
+3. CMS nie podstawia automatycznie nazwy pliku jako tekstu alternatywnego.
+4. CMS ostrzega przed publikacją obrazu bez tekstu alternatywnego, jeżeli obraz nie został oznaczony jako dekoracyjny.
+5. CMS pozwala edytować tekst alternatywny po dodaniu obrazu.
+6. CMS zachowuje tekst alternatywny przy ponownym użyciu tego samego zasobu, ale pozwala go zmienić zależnie od kontekstu.
+7. CMS umożliwia dodanie napisów, transkrypcji lub innych alternatyw dla multimediów, jeżeli obsługuje multimedia.
+8. CMS nie usuwa informacji o dostępności podczas kompresji, optymalizacji, konwersji albo migracji zasobów.
+9. CMS pozwala opisać zasady użycia multimediów w dokumentacji redakcyjnej.
+
+### Dowody odbiorowe
+
+Wykonawca powinien pokazać:
+
+- dodanie obrazu informacyjnego z tekstem alternatywnym,
+- dodanie obrazu dekoracyjnego bez tekstu alternatywnego, ale z poprawnym oznaczeniem dekoracyjności,
+- próbę publikacji obrazu informacyjnego bez tekstu alternatywnego i reakcję CMS,
+- edycję tekstu alternatywnego po publikacji,
+- zachowanie informacji o dostępności po ponownym użyciu obrazu.
+
+## 5. Wymagania dotyczące szablonów i komponentów
+
+CMS powinien dostarczać dostępne szablony i komponenty, które nie generują barier dostępności.
+
+### Minimalne wymagania
+
+1. Wszystkie podstawowe szablony stron spełniają wymagania WCAG na poziomie przyjętym w zamówieniu.
+2. Komponenty redakcyjne są dostępne z klawiatury.
+3. Komponenty mają poprawne role, nazwy, stany i komunikaty.
+4. Komponenty nie wymagają od redaktora ręcznego poprawiania kodu HTML w celu osiągnięcia dostępności.
+5. CMS oznacza, które szablony i komponenty są dostępne, jeżeli zawiera również elementy eksperymentalne, niestandardowe albo wymagające dodatkowej konfiguracji.
+6. Nowe komponenty tworzone w ramach zamówienia przechodzą testy dostępności przed odbiorem.
+7. Wykonawca przekazuje dokumentację korzystania z komponentów zgodnie z zasadami dostępności.
+8. Aktualizacja CMS, szablonu albo komponentu nie może obniżać dostępności bez wcześniejszej informacji i planu naprawczego.
+
+### Dowody odbiorowe
+
+Wykonawca powinien przekazać listę szablonów i komponentów wraz z informacją:
+
+- do czego służy dany element,
+- czy został przetestowany pod kątem dostępności,
+- jakie ograniczenia są znane,
+- jak redaktor powinien go używać,
+- jakich konfiguracji należy unikać.
+
+## 6. Wymagania dotyczące sprawdzania i naprawy błędów
+
+CMS powinien pomagać redaktorom wykrywać i naprawiać podstawowe błędy dostępności przed publikacją.
+
+### Minimalne wymagania
+
+1. CMS sprawdza podstawowe problemy dostępności możliwe do wykrycia automatycznie.
+2. CMS wskazuje miejsce wystąpienia problemu.
+3. CMS wyjaśnia problem prostym językiem.
+4. CMS podpowiada sposób naprawy.
+5. CMS umożliwia ponowne sprawdzenie treści po poprawkach.
+6. CMS generuje raport albo listę problemów dla redaktora.
+7. CMS pozwala organizacji skonfigurować zasady publikacji treści z błędami krytycznymi.
+8. CMS odróżnia błędy możliwe do automatycznego wykrycia od kwestii wymagających oceny człowieka, jeżeli taka funkcja jest dostępna.
+9. Komunikaty o błędach są dostępne dla osób korzystających z technologii wspomagających.
+
+### Przykładowe problemy, które CMS powinien wykrywać
+
+CMS powinien wykrywać co najmniej:
+
+- brak tekstu alternatywnego przy obrazie informacyjnym,
+- pusty tekst alternatywny tam, gdzie obraz nie został oznaczony jako dekoracyjny,
+- pusty nagłówek,
+- zaburzoną strukturę nagłówków, jeżeli jest możliwa do wykrycia,
+- link bez tekstu albo z niejasnym tekstem,
+- tabelę bez nagłówków,
+- brak tytułu strony,
+- nieuzupełnione wymagane pola metadanych, jeżeli wpływają na dostępność albo identyfikację treści.
+
+## 7. Wymagania dotyczące migracji, importu i eksportu treści
+
+CMS powinien zachowywać informacje o dostępności podczas migracji, kopiowania, importu i eksportu treści.
+
+### Minimalne wymagania
+
+1. Kopiowanie treści wewnątrz CMS zachowuje strukturę nagłówków, list, tabel, linków i tekstów alternatywnych.
+2. Import treści nie usuwa tekstów alternatywnych, podpisów, etykiet i struktury semantycznej, jeżeli dane wejściowe je zawierają.
+3. Eksport treści zachowuje informacje o dostępności, jeżeli format wyjściowy na to pozwala.
+4. Mechanizmy optymalizacji obrazów nie usuwają wymaganych informacji o dostępności.
+5. Wykonawca opisuje ograniczenia migracji i wskazuje, które informacje mogą zostać utracone.
+6. Po migracji wykonawca przeprowadza kontrolę próby treści pod kątem zachowania dostępności.
+7. Migracja nie powinna zamieniać dostępnych treści tekstowych na obrazy tekstu.
+
+### Dowody odbiorowe
+
+Wykonawca powinien przekazać:
+
+- opis procesu migracji,
+- listę danych dotyczących dostępności, które są przenoszone,
+- listę danych, które mogą zostać utracone,
+- raport z kontroli próbki zmigrowanych treści,
+- rekomendacje naprawcze dla treści, których nie da się przenieść automatycznie.
+
+## 8. Wymagania dotyczące dokumentacji i szkoleń
+
+Wykonawca powinien przekazać dokumentację i instrukcje, które wspierają dostępne tworzenie treści.
+
+### Minimalne wymagania
+
+1. Dokumentacja CMS jest dostępna cyfrowo.
+2. Dokumentacja zawiera instrukcję tworzenia dostępnych treści w danym CMS.
+3. Dokumentacja pokazuje poprawne przykłady: nagłówki, linki, obrazy, tabele, multimedia, formularze i komponenty.
+4. Dokumentacja nie pokazuje praktyk niedostępnych jako wzorcowych.
+5. Szkolenie dla redaktorów obejmuje funkcje CMS wspierające dostępność.
+6. Wykonawca przekazuje krótką checklistę redaktora.
+7. Wykonawca przekazuje checklistę administratora albo właściciela serwisu.
+8. Wykonawca opisuje, jak zgłaszać i klasyfikować problemy dostępności CMS po wdrożeniu.
+
+## 9. Dowody wymagane od wykonawcy
+
+Wykonawca powinien przekazać co najmniej:
+
+1. macierz zgodności z ATAG 2.0,
+2. raport z testów dostępności panelu CMS,
+3. raport z testów dostępności publicznej części serwisu,
+4. listę znanych ograniczeń,
+5. opis funkcji wspierających tworzenie dostępnych treści,
+6. opis sposobu testowania edytora treści,
+7. dokumentację dla redaktorów,
+8. scenariusze testowe do odbioru,
+9. rekomendacje dotyczące utrzymania dostępności po wdrożeniu,
+10. opis odpowiedzialności za usuwanie błędów dostępności po odbiorze.
+
+## 10. Przykładowe scenariusze odbioru
+
+### Scenariusz 1. Praca redaktora bez myszy
+
+Redaktor wykonuje z klawiatury następujące czynności:
+
+1. loguje się do CMS,
+2. przechodzi do listy treści,
+3. tworzy nową stronę,
+4. uzupełnia tytuł,
+5. dodaje strukturę nagłówków,
+6. dodaje obraz z tekstem alternatywnym,
+7. zapisuje wersję roboczą,
+8. otwiera podgląd,
+9. publikuje treść.
+
+Kryterium zaliczenia: zadanie można wykonać bez użycia myszy, bez pułapek klawiaturowych i bez utraty informacji o stanie interfejsu.
+
+### Scenariusz 2. Dodanie obrazu informacyjnego
+
+Redaktor dodaje obraz informacyjny do treści.
+
+Kryterium zaliczenia: CMS umożliwia dodanie tekstu alternatywnego, zapisuje go, pokazuje w podglądzie albo w kodzie wynikowym i pozwala go później edytować.
+
+### Scenariusz 3. Próba publikacji obrazu bez tekstu alternatywnego
+
+Redaktor próbuje opublikować treść z obrazem informacyjnym bez tekstu alternatywnego.
+
+Kryterium zaliczenia: CMS ostrzega redaktora, wskazuje problem i podpowiada sposób naprawy albo wymaga świadomego oznaczenia obrazu jako dekoracyjnego, jeżeli jest to właściwe.
+
+### Scenariusz 4. Utworzenie tabeli
+
+Redaktor tworzy tabelę z nagłówkami kolumn albo wierszy.
+
+Kryterium zaliczenia: CMS pozwala oznaczyć nagłówki tabeli semantycznie i nie generuje tabeli opartej wyłącznie na formatowaniu wizualnym.
+
+### Scenariusz 5. Sprawdzenie dostępności przed publikacją
+
+Redaktor uruchamia mechanizm sprawdzania dostępności treści.
+
+Kryterium zaliczenia: CMS pokazuje listę problemów, miejsce ich wystąpienia, opis problemu i wskazówki naprawy. Komunikaty są dostępne dla technologii wspomagających.
+
+### Scenariusz 6. Użycie komponentu redakcyjnego
+
+Redaktor dodaje komponent, na przykład akordeon, kartę informacyjną, karuzelę, alert albo blok promocyjny.
+
+Kryterium zaliczenia: komponent działa z klawiatury, ma poprawne nazwy i stany, nie narusza kolejności fokusu i nie wymaga od redaktora ręcznego poprawiania kodu.
+
+## 11. Przykładowy zapis do OPZ
+
+System CMS musi być zaprojektowany i wdrożony z uwzględnieniem wytycznych ATAG 2.0. Wymaganie obejmuje dostępność interfejsu narzędzia dla redaktorów, administratorów i osób zatwierdzających treści oraz funkcje wspierające tworzenie, sprawdzanie i poprawianie dostępnych treści.
+
+Wykonawca zobowiązany jest zapewnić dostępność panelu CMS, edytora treści, biblioteki mediów, szablonów, komponentów, mechanizmów podglądu, procesu publikacji i dokumentacji użytkownika. Wykonawca zobowiązany jest również przekazać macierz zgodności z ATAG 2.0, opis funkcji wspierających dostępność, listę znanych ograniczeń oraz scenariusze testowe umożliwiające odbiór dostępności CMS.
+
+CMS musi umożliwiać redaktorom tworzenie dostępnych treści bez konieczności ręcznej edycji kodu HTML w podstawowych scenariuszach redakcyjnych. W szczególności CMS musi umożliwiać tworzenie poprawnej struktury nagłówków, linków, list, tabel, tekstów alternatywnych dla obrazów, oznaczanie grafik dekoracyjnych oraz sprawdzanie podstawowych błędów dostępności przed publikacją.
+
+## 12. Przykładowy zapis do umowy
+
+Wykonawca odpowiada za zapewnienie dostępności cyfrowej publicznej części serwisu oraz za dostępność panelu CMS i mechanizmów wspierających tworzenie dostępnych treści. Odpowiedzialność wykonawcy obejmuje w szczególności szablony, komponenty, edytor treści, formularze administracyjne, bibliotekę mediów, mechanizmy podglądu, proces publikacji, dokumentację i konfigurację systemu.
+
+Wykonawca zobowiązuje się do usunięcia błędów dostępności stwierdzonych w trakcie odbioru, jeżeli wynikają one z projektu, konfiguracji, komponentów, szablonów, edytora, dokumentacji albo innych elementów CMS dostarczonych w ramach zamówienia.
+
+Wykonawca zobowiązuje się nie obniżać poziomu dostępności CMS w ramach aktualizacji, poprawek serwisowych lub rozwoju systemu. W przypadku ryzyka obniżenia dostępności wykonawca zobowiązany jest poinformować zamawiającego, opisać wpływ zmiany i przedstawić plan naprawczy.
+
+## 13. Przykładowy zapis do kryteriów oceny ofert
+
+Zamawiający może przyznać dodatkowe punkty za rozwiązania, które wykraczają poza minimalne wymagania, w szczególności za:
+
+1. wyższy poziom zgodności z ATAG 2.0,
+2. wbudowany mechanizm sprawdzania dostępności treści,
+3. dostępne szablony i komponenty potwierdzone testami,
+4. wsparcie redaktora w naprawie błędów dostępności,
+5. jakość dokumentacji i checklist dla redaktorów,
+6. demonstrację dostępnego procesu redakcyjnego,
+7. możliwość konfiguracji reguł publikacji treści z błędami krytycznymi,
+8. zachowanie informacji o dostępności podczas migracji i ponownego użycia treści.
+
+## 14. Przykładowa tabela zgodności z ATAG
+
+| Obszar | Wymaganie | Status | Dowód | Ograniczenia | Działania naprawcze |
+|---|---|---|---|---|---|
+| Dostępność panelu | Kluczowe funkcje panelu są dostępne z klawiatury | spełnione / częściowo / niespełnione / nie dotyczy | opis, test, nagranie, raport | do uzupełnienia | do uzupełnienia |
+| Edytor treści | Redaktor może tworzyć semantyczne nagłówki | spełnione / częściowo / niespełnione / nie dotyczy | opis, test, zrzut, kod wynikowy | do uzupełnienia | do uzupełnienia |
+| Obrazy | CMS umożliwia dodanie tekstu alternatywnego | spełnione / częściowo / niespełnione / nie dotyczy | scenariusz testowy | do uzupełnienia | do uzupełnienia |
+| Sprawdzanie błędów | CMS wskazuje podstawowe błędy dostępności | spełnione / częściowo / niespełnione / nie dotyczy | demonstracja, raport | do uzupełnienia | do uzupełnienia |
+| Szablony | Szablony nie generują błędów dostępności | spełnione / częściowo / niespełnione / nie dotyczy | audyt, test komponentów | do uzupełnienia | do uzupełnienia |
+| Dokumentacja | Dokumentacja opisuje tworzenie dostępnych treści | spełnione / częściowo / niespełnione / nie dotyczy | dokumentacja | do uzupełnienia | do uzupełnienia |
+
+## 15. Lista minimalna do małego zamówienia
+
+Jeżeli zamówienie jest niewielkie, zamawiający powinien zachować co najmniej następujące wymagania:
+
+1. Panel CMS działa z klawiatury w podstawowych scenariuszach redakcyjnych.
+2. Edytor pozwala tworzyć nagłówki, listy, linki, tabele i teksty alternatywne w sposób semantyczny.
+3. CMS nie generuje niedostępnych szablonów ani komponentów przy standardowym użyciu.
+4. CMS ostrzega przed brakiem tekstu alternatywnego dla obrazu informacyjnego.
+5. Wykonawca przekazuje instrukcję tworzenia dostępnych treści w CMS.
+6. Odbiór obejmuje co najmniej jeden scenariusz utworzenia, sprawdzenia i publikacji dostępnej strony.
+7. Wykonawca przekazuje listę znanych ograniczeń dostępności CMS.
+
+## 16. Źródła i opracowania
+
+1. [W3C WAI, *Authoring Tool Accessibility Guidelines (ATAG) 2.0*](https://www.w3.org/TR/ATAG20/), dostęp: 10 czerwca 2026 r.
+2. [W3C WAI, *Omówienie Wytycznych dla dostępności narzędzi autorskich (ATAG)*](https://www.w3.org/WAI/standards-guidelines/atag/pl), dostęp: 10 czerwca 2026 r.
+3. [W3C WAI, *ATAG w skrócie*](https://www.w3.org/WAI/standards-guidelines/atag/glance/pl), dostęp: 10 czerwca 2026 r.
+4. [W3C WAI, *ATAG Conformance Evaluation Report Tool*](https://www.w3.org/WAI/atag/report-tool/), dostęp: 10 czerwca 2026 r.

--- a/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/lista-wymagan-atag-dla-cms-opz-swz.md
+++ b/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/lista-wymagan-atag-dla-cms-opz-swz.md
@@ -330,7 +330,7 @@ Jeżeli zamówienie jest niewielkie, zamawiający powinien zachować co najmniej
 4. CMS ostrzega przed brakiem tekstu alternatywnego dla obrazu informacyjnego.
 5. Wykonawca przekazuje instrukcję tworzenia dostępnych treści w CMS.
 6. Odbiór obejmuje co najmniej jeden scenariusz utworzenia, sprawdzenia i publikacji dostępnej strony.
-7. Wykonawca przekazuje listę znanych ograniczeń dostępności CMS.
+7. Wykonawca przekazuje listę znanych ograniczeń dostępności CMS. 
 
 ## 16. Źródła i opracowania
 

--- a/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/uwzglednianie-atag-przy-zamawianiu-cms.md
+++ b/documentation/docs/zaopatrzenie/zamawianie-systemow-cms/uwzglednianie-atag-przy-zamawianiu-cms.md
@@ -1,0 +1,156 @@
+---
+id: uwzglednianie-atag-przy-zamawianiu-cms
+title: Uwzględnianie ATAG przy zamawianiu systemów CMS
+sidebar_position: 0
+description: Rekomendacja dotycząca stosowania wytycznych ATAG 2.0 przy zamawianiu, wdrażaniu, utrzymywaniu i odbiorze systemów zarządzania treścią.
+keywords: [ATAG, CMS, zamówienia publiczne, dostępność cyfrowa, WCAG, narzędzia autorskie, OPZ, SWZ]
+tags: [ATAG, CMS, zaopatrzenie, komunikacja, dostępność cyfrowa]
+opracowanie: Damian Żłobicki
+data_zgloszenia: 10 czerwca 2026 r.
+ostatnia_aktualizacja: 10 czerwca 2026 r.
+wersja_robocza: true
+---
+
+## Zalecenie
+
+Podmiot publiczny powinien uwzględniać wytyczne ATAG 2.0 przy zamawianiu, projektowaniu, wdrażaniu, utrzymywaniu i odbiorze systemów zarządzania treścią, w szczególności systemów CMS, BIP, portali informacyjnych, intranetów, platform publikacyjnych oraz innych narzędzi, w których pracownicy tworzą, edytują, zatwierdzają lub publikują treści cyfrowe.
+
+Wymagania dostępności nie powinny ograniczać się do publicznej części serwisu internetowego. Powinny obejmować także panel administracyjny, edytor treści, bibliotekę mediów, szablony, komponenty, formularze administracyjne, mechanizmy podglądu, proces publikacji, dokumentację oraz funkcje, które pomagają redaktorom tworzyć dostępne treści.
+
+CMS należy traktować jako narzędzie autorskie. Oznacza to, że powinien spełniać dwa typy wymagań:
+
+1. **dostępność narzędzia dla autorów i redaktorów** — panel CMS, edytor i funkcje administracyjne powinny być dostępne dla osób z niepełnosprawnościami;
+2. **wsparcie tworzenia dostępnych treści** — CMS powinien umożliwiać, ułatwiać i promować tworzenie treści zgodnych z wymaganiami dostępności cyfrowej.
+
+Zamawiający powinien wymagać od wykonawcy wykazania, w jaki sposób oferowany CMS spełnia wymagania ATAG 2.0. Wykonawca powinien przedstawić macierz zgodności, opis spełnienia wymagań, znane ograniczenia, ryzyka oraz sposób ich usunięcia albo ograniczenia.
+
+## Rekomendacje
+
+1. **Uwzględnij ATAG już na etapie planowania zamówienia.**  
+   Wymagania dotyczące dostępności CMS powinny zostać opisane przed wyborem technologii, wykonawcy i architektury rozwiązania. Nie należy zostawiać ich wyłącznie na etap odbioru.
+
+2. **Opisz dostępność całego procesu redakcyjnego.**  
+   W dokumentacji zamówienia należy wskazać, że wymagania dostępności obejmują:
+   - publiczną część serwisu,
+   - panel administracyjny CMS,
+   - edytor treści,
+   - bibliotekę mediów,
+   - szablony stron i podstron,
+   - komponenty redakcyjne,
+   - formularze administracyjne,
+   - mechanizmy tworzenia formularzy publicznych,
+   - podgląd treści,
+   - proces zapisu, akceptacji i publikacji,
+   - dokumentację użytkownika,
+   - szkolenia dla redaktorów i administratorów.
+
+3. **Rozdziel wymagania WCAG i ATAG.**  
+   WCAG powinien być stosowany do oceny publicznej części serwisu oraz, w odpowiednim zakresie, webowego interfejsu CMS. ATAG powinien być stosowany do oceny CMS jako narzędzia autorskiego, czyli narzędzia służącego do tworzenia i publikowania treści.
+
+4. **Wymagaj dostępnego panelu CMS.**  
+   Panel CMS powinien umożliwiać wykonanie podstawowych i zaawansowanych zadań redakcyjnych bez barier dostępności. W szczególności powinien zapewniać:
+   - obsługę kluczowych funkcji z klawiatury,
+   - brak pułapek klawiaturowych,
+   - widoczny fokus,
+   - poprawne nazwy dostępne elementów interfejsu,
+   - logiczną kolejność nawigacji,
+   - dostępne formularze administracyjne,
+   - zrozumiałe komunikaty błędów,
+   - dostępne komunikaty statusu,
+   - możliwość pracy z technologiami wspomagającymi,
+   - dostępny edytor treści albo dostępny alternatywny tryb edycji.
+
+5. **Wymagaj funkcji wspierających tworzenie dostępnych treści.**  
+   CMS powinien pomagać redaktorom tworzyć dostępne treści, w szczególności przez:
+   - możliwość dodawania i edytowania tekstów alternatywnych,
+   - możliwość oznaczania grafik dekoracyjnych,
+   - ostrzeganie przed brakiem wymaganego tekstu alternatywnego,
+   - tworzenie poprawnej struktury nagłówków,
+   - tworzenie semantycznych list, tabel, cytatów i linków,
+   - sprawdzanie podstawowych błędów dostępności przed publikacją,
+   - wskazywanie miejsca błędu,
+   - podpowiadanie sposobu naprawy,
+   - korzystanie z dostępnych szablonów i komponentów,
+   - zachowywanie informacji o dostępności przy kopiowaniu, imporcie, eksporcie i migracji treści.
+
+6. **Nie przerzucaj odpowiedzialności za błędy systemu na redaktorów.**  
+   Redaktor powinien odpowiadać za jakość tworzonej treści, ale nie powinien naprawiać błędów wynikających z wadliwego szablonu, komponentu, edytora albo konfiguracji CMS. Jeśli CMS generuje niedostępny kod, problem powinien zostać potraktowany jako wada systemu.
+
+7. **Wymagaj macierzy zgodności z ATAG 2.0.**  
+   Wykonawca powinien przedstawić zestawienie wymagań ATAG 2.0 z informacją, czy dane wymaganie jest:
+   - spełnione,
+   - częściowo spełnione,
+   - niespełnione,
+   - niemożliwe do zastosowania w danym rozwiązaniu.
+
+   Dla każdego wymagania wykonawca powinien wskazać dowód, opis działania funkcji, ograniczenia oraz ewentualne działania naprawcze.
+
+8. **Stosuj wymagania proporcjonalne, ale mierzalne.**  
+   Standardem docelowym powinna być zgodność z ATAG 2.0 na poziomie AA w zakresie funkcji objętych zamówieniem. Jeżeli pełna zgodność nie jest możliwa albo proporcjonalna, zamawiający powinien określić minimalny profil wymagań, wskazać wymagania krytyczne i wymagać od wykonawcy planu usunięcia ograniczeń.
+
+9. **Nie poprzestawaj na ogólnym zapisie „CMS ma być dostępny cyfrowo”.**  
+   Taki zapis jest zbyt ogólny i trudny do odebrania. Należy opisać konkretne funkcje, scenariusze pracy redaktora, dowody zgodności i kryteria odbioru.
+
+10. **Uwzględnij ATAG w kryteriach odbioru.**  
+    Odbiór systemu powinien obejmować nie tylko publiczną część serwisu, ale również:
+    - logowanie i nawigację po panelu CMS,
+    - utworzenie nowej strony,
+    - edycję istniejącej strony,
+    - dodanie obrazu z tekstem alternatywnym,
+    - oznaczenie obrazu dekoracyjnego,
+    - utworzenie struktury nagłówków,
+    - dodanie linku, listy i tabeli,
+    - osadzenie multimediów wraz z alternatywami,
+    - użycie mechanizmu sprawdzania dostępności,
+    - poprawienie wykrytych błędów,
+    - podgląd i publikację treści,
+    - korzystanie z dokumentacji redakcyjnej.
+
+11. **Wymagaj dokumentacji i szkoleń redakcyjnych.**  
+    Dokumentacja CMS powinna być dostępna cyfrowo i powinna opisywać, jak tworzyć dostępne treści w konkretnym wdrożeniu. Szkolenia dla redaktorów powinny obejmować nie tylko obsługę CMS, ale także funkcje wspierające dostępność.
+
+12. **Zaplanuj utrzymanie dostępności po wdrożeniu.**  
+    Zamawiający powinien zapewnić proces utrzymania dostępności CMS i treści, obejmujący:
+    - aktualizację szablonów i komponentów,
+    - cykliczne testy panelu CMS po aktualizacjach,
+    - przeglądy nowych treści,
+    - obsługę zgłoszeń użytkowników,
+    - szkolenia przypominające dla redaktorów,
+    - reaudyt po większych zmianach systemu.
+
+## Uzasadnienie
+
+System CMS ma bezpośredni wpływ na dostępność treści publikowanych przez podmiot publiczny. Nawet poprawnie zaprojektowana strona internetowa może szybko stać się niedostępna, jeżeli CMS nie wspiera redaktorów w tworzeniu dostępnych treści albo generuje błędny kod.
+
+Dostępność cyfrowa nie kończy się w momencie wdrożenia serwisu. Strona internetowa, BIP, intranet albo portal informacyjny są później rozwijane, aktualizowane i uzupełniane przez pracowników podmiotu. Dlatego narzędzie, w którym powstają treści, powinno wspierać dostępność na etapie codziennej pracy redakcyjnej.
+
+Brak wymagań ATAG w zamówieniu powoduje trzy podstawowe ryzyka.
+
+Po pierwsze, osoby z niepełnosprawnościami mogą nie mieć możliwości pracy w panelu CMS. Dotyczy to między innymi redaktorów korzystających z klawiatury, czytników ekranu, powiększenia, ustawień wysokiego kontrastu albo innych technologii wspomagających.
+
+Po drugie, redaktorzy mogą nie mieć narzędzi pozwalających tworzyć dostępne treści. Jeżeli CMS nie pozwala poprawnie dodać tekstu alternatywnego, utworzyć logicznej struktury nagłówków, przygotować dostępnej tabeli albo sprawdzić błędów przed publikacją, odpowiedzialność za dostępność staje się pozorna.
+
+Po trzecie, błędy systemowe mogą być powielane w dużej skali. Niedostępny szablon, komponent albo edytor może wygenerować setki niedostępnych podstron, komunikatów lub dokumentów. Usuwanie takich błędów po publikacji jest zwykle droższe i trudniejsze niż wymaganie dostępności na etapie zamówienia.
+
+Uwzględnienie ATAG porządkuje odpowiedzialność między zamawiającym, wykonawcą i redaktorami. Wykonawca odpowiada za dostępność narzędzia, szablonów, komponentów, konfiguracji i dokumentacji. Zamawiający odpowiada za opisanie wymagań, odbiór, organizację procesu publikacji i utrzymanie standardu. Redaktorzy odpowiadają za treść, ale powinni otrzymać narzędzie, które pomaga im tworzyć ją poprawnie.
+
+Stosowanie ATAG przy zamawianiu CMS wzmacnia trwałość dostępności cyfrowej. Nie chodzi wyłącznie o jednorazowe spełnienie wymagań przy odbiorze serwisu. Chodzi o stworzenie warunków, w których dostępność jest wspierana przez narzędzie, proces i kompetencje pracowników.
+
+## Podstawy prawne i standardy
+
+W zaleceniu uwzględniono poniżej wymienione akty, normy i standardy:
+
+- Dyrektywa Parlamentu Europejskiego i Rady (UE) 2016/2102 z dnia 26 października 2016 r. w sprawie dostępności stron internetowych i mobilnych aplikacji organów sektora publicznego.
+- Ustawa z dnia 4 kwietnia 2019 r. o dostępności cyfrowej stron internetowych i aplikacji mobilnych podmiotów publicznych.
+- Ustawa z dnia 11 września 2019 r. — Prawo zamówień publicznych, w szczególności przepisy dotyczące uwzględniania dostępności oraz projektowania z przeznaczeniem dla wszystkich użytkowników w opisie przedmiotu zamówienia.
+- EN 301 549 — Accessibility requirements for ICT products and services.
+- WCAG 2.1 oraz WCAG 2.2 jako standardy oceny dostępności treści internetowych i interfejsów webowych.
+- ATAG 2.0 jako standard dotyczący dostępności narzędzi autorskich oraz wspierania tworzenia dostępnych treści.
+
+## Źródła i opracowania
+
+1. [W3C WAI, *Authoring Tool Accessibility Guidelines (ATAG) 2.0*](https://www.w3.org/TR/ATAG20/), dostęp: 10 czerwca 2026 r.
+2. [W3C WAI, *Omówienie Wytycznych dla dostępności narzędzi autorskich (ATAG)*](https://www.w3.org/WAI/standards-guidelines/atag/pl), dostęp: 10 czerwca 2026 r.
+3. [W3C WAI, *ATAG w skrócie*](https://www.w3.org/WAI/standards-guidelines/atag/glance/pl), dostęp: 10 czerwca 2026 r.
+4. [W3C WAI, *ATAG Conformance Evaluation Report Tool*](https://www.w3.org/WAI/atag/report-tool/), dostęp: 10 czerwca 2026 r.
+5. [W3C WAI, *Web Content Accessibility Guidelines (WCAG) Overview*](https://www.w3.org/WAI/standards-guidelines/wcag/), dostęp: 10 czerwca 2026 r.


### PR DESCRIPTION
## Co zmieniono

- dodano zalecenie dotyczące uwzględniania ATAG 2.0 przy zamawianiu systemów CMS,
- dodano praktyczną listę wymagań ATAG dla CMS do wykorzystania w OPZ, SWZ, umowach i odbiorach,
- utworzono kategorię „Zamawianie systemów CMS” w sekcji Zaopatrzenie.

[Zobacz podgląd dokumentów](https://deploy-preview-198--siec-dostepnosci-cyfrowej.netlify.app/docs/category/zamawianie-system%C3%B3w-cms)

