### PR TITLE
Obserwowanie i ocenianie stanu dostępności i zgodności

### DIFF
--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/_category_.json
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Obserwowanie i ocenianie stanu dostępności i zgodności",
+  "position": 7,
+  "link": {
+    "type": "generated-index",
+	"description": "Pakiet przedstawia zasady systematycznego obserwowania i oceniania stanu dostępności i zgodności rozwiązań cyfrowych. Wspiera uzyskiwanie, aktualizowanie, rozszerzanie i pogłębianie wiedzy o stanie oraz jej dokumentowanie i wykorzystywanie w procesach zapewniania dostępności."
+  }
+}

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
@@ -22,7 +22,7 @@ Analiza wspiera planowanie dalszych ocen na podstawie wiedzy zgromadzonej w reje
 
 Wiedza o stanie dostępności i zgodności rozwiązania jest uzyskiwana stopniowo podczas obserwacji i ocen prowadzonych w całym okresie jego użytkowania.
 
-Posiadanie informacji o stwierdzonych problemach lub wynikach ocen nie oznacza, że organizacja posiada wystarczającą wiedzę o całym rozwiązaniu.
+Posiadanie informacji o stwierdzonych problemach lub wynikach ocen nie oznacza, że organizacja ma wystarczającą wiedzę o całym rozwiązaniu.
 
 Analiza zakresu rozpoznania służy ustaleniu:
 

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
@@ -1,0 +1,150 @@
+---
+id: analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci
+title: Analiza zakresu rozpoznania stanu dostępności i zgodności
+description: Narzędzie wspierające ustalanie, co organizacja wie o stanie dostępności i zgodności rozwiązania cyfrowego, czego jeszcze nie wie oraz jakie obszary powinny zostać objęte kolejnymi ocenami.
+sidebar_label: Analiza zakresu rozpoznania
+sidebar_position: 5
+keywords: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
+tags: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+## Cel dokumentu
+
+Dokument określa zasady analizowania zakresu rozpoznania stanu dostępności i zgodności rozwiązania cyfrowego w celu ustalenia, co już wiadomo o jego stanie, jakich informacji brakuje oraz które informacje wymagają aktualizacji lub weryfikacji.
+
+Analiza wspiera planowanie dalszych ocen na podstawie wiedzy zgromadzonej w rejestrze stanu dostępności i zgodności.
+
+## 1. Rola analizy zakresu rozpoznania
+
+Wiedza o stanie dostępności i zgodności rozwiązania jest uzyskiwana stopniowo podczas obserwacji i ocen prowadzonych w całym okresie jego użytkowania.
+
+Posiadanie informacji o stwierdzonych problemach lub wynikach ocen nie oznacza, że organizacja posiada wystarczającą wiedzę o całym rozwiązaniu.
+
+Analiza zakresu rozpoznania służy ustaleniu:
+
+- jakie wymagania zostały objęte oceną;
+- jakie części rozwiązania i sposoby korzystania z niego zostały rozpoznane;
+- jakie obiekty tworzyły badaną próbę;
+- które informacje pozostają aktualne;
+- czego jeszcze nie oceniono;
+- które informacje wymagają aktualizacji, uzupełnienia albo weryfikacji.
+
+Wyniki analizy stanowią podstawę do ustalania potrzeb dalszego oceniania.
+
+## 2. Przedmiot i podstawa analizy
+
+Zakres rozpoznania stanu określa, jakiej części rozwiązania i mających zastosowanie wymagań dotyczy aktualna i wiarygodna wiedza organizacji.
+
+Analizuje się go w trzech wymiarach:
+
+1. **zakres wymagań**;
+2. **zakres funkcjonalny**;
+3. **zakres badanej próby**.
+
+Wymiary te należy rozpatrywać łącznie. Szeroki zakres ocenionych wymagań nie oznacza szerokiego rozpoznania stanu, jeżeli oceny dotyczyły niewielkiej lub niereprezentatywnej części rozwiązania. Podobnie szeroka próba obiektów nie oznacza szerokiego rozpoznania, jeżeli oceniono jedynie niewielką część mających zastosowanie wymagań.
+
+Analizę przeprowadza się na podstawie informacji zgromadzonych w rejestrze stanu dostępności i zgodności.
+
+Analiza nie polega na ponownym ocenianiu rozwiązania. Służy ustaleniu zakresu i aktualności posiadanej wiedzy.
+
+
+## 3. Analizowanie zakresu rozpoznania
+
+### 3.1. Zakres wymagań
+
+Organizacja ustala:
+
+- jakie wymagania mają zastosowanie do rozwiązania;
+- które wymagania zostały objęte ocenami i w jakim zakresie;
+- czy posiadane informacje są aktualne i wystarczające;
+- które wymagania wymagają dalszej oceny.
+
+Wykonanie scenariusza testu nie oznacza automatycznie pełnego rozpoznania zgodności z wymaganiem. To samo wymaganie może wymagać oceny w różnych częściach rozwiązania, procesach użytkownika, komponentach lub rodzajach treści.
+
+### 3.2. Zakres funkcjonalny
+
+Organizacja ustala, jakie części rozwiązania i sposoby korzystania z niego zostały objęte ocenami oraz które z nich są rozpoznane w wystarczającym zakresie, rozpoznane częściowo, nieobjęte oceną albo wymagają aktualizacji lub weryfikacji wiedzy.
+
+Szczególną uwagę należy zwracać na kluczowe procesy użytkownika. Ocena poszczególnych stron, ekranów lub elementów nie oznacza rozpoznania dostępności całego procesu.
+
+### 3.3. Zakres badanej próby
+
+Organizacja ustala, jakie obiekty zostały objęte ocenami i w jakim zakresie reprezentują zróżnicowane i istotne części rozwiązania.
+
+Celem analizy nie jest ustalenie odsetka ocenionych obiektów, lecz wskazanie, jakie części rozwiązania są reprezentowane w dotychczasowych ocenach i jakie obiekty powinny zostać objęte dalszym ocenianiem.
+
+
+## 4. Ocena aktualności wiedzy
+
+Przy określaniu zakresu rozpoznania uwzględnia się aktualność posiadanych informacji.
+
+Informacje nieaktualne albo wymagające weryfikacji nie powinny być traktowane na równi z aktualną wiedzą. Samo przeprowadzenie oceny w przeszłości nie oznacza, że objęty nią zakres pozostaje rozpoznany w chwili przeprowadzania analizy.
+
+
+## 5. Identyfikowanie luk w wiedzy
+
+Luka w wiedzy występuje wtedy, gdy organizacja nie posiada aktualnych i wystarczających informacji potrzebnych do wiarygodnego ustalenia stanu dostępności lub zgodności w określonym zakresie.
+
+Luka może wynikać w szczególności z:
+
+- nieobjęcia oceną wymagania, części rozwiązania lub procesu użytkownika;
+- niewystarczającej reprezentatywności badanej próby;
+- utraty aktualności wcześniejszych informacji;
+- potrzeby weryfikacji wcześniejszego ustalenia;
+- rozbieżnych lub niewystarczających informacji.
+
+Brak stwierdzonych problemów nie oznacza braku luk w wiedzy. Luki wynikają z zakresu, aktualności i wystarczalności posiadanych informacji, a nie z liczby stwierdzonych niezgodności.
+
+## 6. Ustalanie potrzeb dalszego oceniania
+
+Zidentyfikowanie luki w wiedzy nie oznacza automatycznie konieczności natychmiastowego przeprowadzenia oceny.
+
+Na podstawie analizy organizacja ustala potrzeby dalszego oceniania, uwzględniając w szczególności:
+
+- znaczenie rozwiązania, funkcji i procesów dla użytkowników;
+- zakres i znaczenie brakującej wiedzy;
+- ryzyko występowania problemów dostępności;
+- zmiany mogące wpływać na aktualność wcześniejszych ustaleń;
+- informacje pochodzące ze zgłoszeń, skarg i innych źródeł;
+- potrzeby informacyjne związane z decyzjami i procesami organizacji.
+
+Wyniki analizy wykorzystuje się do ustalania celu i zakresu kolejnych ocen planowych, doboru profilu oraz wyboru wymagań, części rozwiązania i obiektów wymagających dalszego oceniania.
+
+Celem nie jest usunięcie wszystkich luk podczas jednej oceny, lecz planowe zwiększanie i utrzymywanie zakresu aktualnej wiedzy o stanie rozwiązania.
+
+## 7. Wynik analizy
+
+Wynik analizy powinien umożliwiać ustalenie:
+
+- aktualnego zakresu rozpoznania stanu;
+- najważniejszych luk w wiedzy;
+- informacji wymagających aktualizacji lub weryfikacji;
+- potrzeb dalszego oceniania.
+
+Wynik może być przedstawiony w formie odpowiedniej do wielkości i złożoności rozwiązania oraz sposobu prowadzenia rejestru, na przykład jako zestawienie, widok lub raport generowany z rejestru albo lista potrzeb dalszego oceniania.
+
+Analiza nie musi prowadzić do utworzenia odrębnego dokumentu, jeżeli jej wynik może zostać ustalony i wykorzystany bezpośrednio na podstawie informacji zgromadzonych w rejestrze.
+
+
+## 8. Proste zestawienie wyników analizy
+
+Wyniki analizy można przedstawić w prostym zestawieniu pokazującym, które części rozwiązania i wymagania zostały rozpoznane oraz gdzie występują potrzeby dalszego oceniania.
+
+Przykład:
+
+| Wymaganie lub grupa wymagań | Obszar A    | Obszar B           | Proces C    | Dokumenty   | Potrzeba dalszej oceny                |
+| --------------------------- | ----------- | ------------------ | ----------- | ----------- | ------------------------------------- |
+| Struktura i semantyka       | rozpoznano  | częściowo          | rozpoznano  | brak danych | ocena dokumentów                      |
+| Obsługa klawiaturą          | rozpoznano  | wymaga weryfikacji | częściowo   | nie dotyczy | weryfikacja obszaru B i ocena procesu |
+| Formularze i komunikaty     | nie dotyczy | rozpoznano         | częściowo   | nie dotyczy | rozszerzenie oceny procesu            |
+| Multimedia                  | brak danych | nie dotyczy        | nie dotyczy | częściowo   | ocena multimediów                     |
+
+Zestawienie ma charakter pomocniczy. Jego zakres, układ i stosowane oznaczenia można dostosować do rodzaju rozwiązania, potrzeb organizacji i sposobu prowadzenia rejestru.
+
+Zastosowane w przykładzie oznaczenia mają charakter ilustracyjny i nie stanowią wymaganej skali oceny zakresu rozpoznania.
+
+

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
@@ -14,7 +14,7 @@ wersja_robocza: true
 
 ## Cel dokumentu
 
-Dokument określa zasady analizowania zakresu rozpoznania stanu dostępności i zgodności rozwiązania cyfrowego w celu ustalenia, co już wiadomo o jego stanie, jakich informacji brakuje oraz które informacje wymagają aktualizacji lub weryfikacji.
+Dokument określa zasady przeprowadzania analizy zakresu rozpoznania stanu dostępności i zgodności rozwiązania cyfrowego. Analiza służy ustaleniu aktualnego zakresu wiedzy organizacji, w tym informacji brakujących, nieaktualnych lub wymagających weryfikacji.
 
 Analiza wspiera planowanie dalszych ocen na podstawie wiedzy zgromadzonej w rejestrze stanu dostępności i zgodności.
 

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
@@ -16,7 +16,7 @@ wersja_robocza: true
 
 Dokument określa zasady przeprowadzania analizy zakresu rozpoznania stanu dostępności i zgodności rozwiązania cyfrowego. Analiza służy ustaleniu aktualnego zakresu wiedzy organizacji, w tym informacji brakujących, nieaktualnych lub wymagających weryfikacji.
 
-Analiza wspiera planowanie dalszych ocen na podstawie wiedzy zgromadzonej w rejestrze stanu dostępności i zgodności.
+Analiza ma charakter cykliczny i wspiera zarządzanie ryzykiem dostępności, umożliwiając ustalenie priorytetów dalszego oceniania oraz planowe utrzymywanie aktualnej wiedzy o stanie rozwiązania na podstawie danych zgromadzonych w rejestrze.
 
 ## 1. Rola analizy zakresu rozpoznania
 

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
@@ -30,7 +30,7 @@ Analiza zakresu rozpoznania służy ustaleniu:
 - jakie części rozwiązania i sposoby korzystania z niego zostały rozpoznane;
 - jakie obiekty tworzyły badaną próbę;
 - które informacje pozostają aktualne;
-- czego jeszcze nie oceniono;
+- czego jeszcze nie oceniono lub oceniono w niewystarczającym zakresie;
 - które informacje wymagają aktualizacji, uzupełnienia albo weryfikacji.
 
 Wyniki analizy stanowią podstawę do ustalania potrzeb dalszego oceniania.

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci.md
@@ -26,7 +26,7 @@ Posiadanie informacji o stwierdzonych problemach lub wynikach ocen nie oznacza, 
 
 Analiza zakresu rozpoznania służy ustaleniu:
 
-- jakie wymagania zostały objęte oceną;
+- jakie wymagania zostały objęte oceną oraz w jakim zakresie;
 - jakie części rozwiązania i sposoby korzystania z niego zostały rozpoznane;
 - jakie obiekty tworzyły badaną próbę;
 - które informacje pozostają aktualne;

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/obserwowanie-i-ocenianie-stanu-dostepnosci-i-zgodnosci-rozwiazan-cyfrowych.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/obserwowanie-i-ocenianie-stanu-dostepnosci-i-zgodnosci-rozwiazan-cyfrowych.md
@@ -15,21 +15,29 @@ wersja_robocza: true
 
 ## Cel zalecenia
 
-Zapewnienie organizacji aktualnej i udokumentowanej wiedzy o stanie dostępności i zgodności rozwiązań cyfrowych oraz zakresie rozpoznania tego stanu.
+Wspieranie skutecznego zapewniania dostępności cyfrowej przez systematyczne uzyskiwanie, aktualizowanie i wykorzystywanie wiedzy o stanie dostępności i zgodności rozwiązań cyfrowych.
 
 ## Zalecenie
 
 Organizacja systematycznie obserwuje i ocenia stan dostępności i zgodności rozwiązań cyfrowych w całym okresie ich użytkowania.
 
-Informacje uzyskiwane podczas bieżącej działalności oraz ocen planowych i doraźnych organizacja przetwarza i wykorzystuje do aktualizowania wiedzy o stanie, analizowania zakresu jego rozpoznania oraz planowania dalszych ocen.
+Informacje uzyskiwane podczas bieżącej działalności oraz ocen planowych i doraźnych organizacja przetwarza, dokumentuje i wykorzystuje do podejmowania decyzji i działań służących zapewnianiu dostępności cyfrowej, aktualizowania wiedzy o stanie rozwiązań oraz planowania dalszych ocen.
+
 
 ## Rekomendacje
 
 ### Systematyczne obserwowanie i ocenianie stanu
 
-Organizacja traktuje obserwowanie i ocenianie stanu jako ciągły i iteracyjny proces rozwijania oraz aktualizowania wiedzy o rozwiązaniu cyfrowym.
+Organizacja systematycznie obserwuje i ocenia stan dostępności i zgodności rozwiązań cyfrowych, aby uzyskiwać informacje potrzebne do podejmowania decyzji i działań służących zapewnianiu dostępności cyfrowej.
 
-W procesie wykorzystuje informacje uzyskiwane podczas bieżącej działalności oraz wyniki ocen planowych i doraźnych.
+W procesie wykorzystuje informacje uzyskiwane podczas bieżącej działalności oraz wyniki ocen planowych i doraźnych, zachowując i aktualizując wiedzę o stanie rozwiązań.
+
+### Wykorzystywanie wiedzy o stanie
+
+Organizacja wykorzystuje aktualną wiedzę o stanie dostępności i zgodności do podejmowania decyzji i działań służących zapewnianiu dostępności cyfrowej.
+
+Wiedzę wykorzystuje w szczególności do identyfikowania i usuwania problemów dostępności, planowania działań naprawczych i doskonalących, oceny zmian, obsługi zgłoszeń użytkowników, odbioru i utrzymania rozwiązań cyfrowych oraz przeglądu i aktualizacji deklaracji dostępności.
+
 
 ### Prowadzenie ocen planowych i doraźnych
 
@@ -87,17 +95,22 @@ Sposób podziału odpowiedzialności dostosowuje do swojej wielkości i struktur
 
 ## Uzasadnienie
 
-Stan dostępności i zgodności rozwiązania cyfrowego zmienia się w całym okresie jego użytkowania. Wpływają na niego między innymi zmiany funkcjonalności, technologii i treści, działania naprawcze, aktualizacje oraz informacje uzyskiwane od użytkowników.
+Skuteczne zapewnianie dostępności cyfrowej wymaga podejmowania decyzji i działań na podstawie aktualnych i wiarygodnych informacji o stanie rozwiązań cyfrowych. Organizacja powinna wiedzieć, gdzie występują problemy dostępności, jakie jest ich znaczenie dla użytkowników, które części rozwiązania wymagają działania oraz czy podjęte działania przyniosły oczekiwane rezultaty.
 
-Pojedyncza ocena lub audyt przedstawia stan rozpoznany w określonym czasie i zakresie. Kolejne niezależne oceny nie zapewniają same w sobie aktualnej wiedzy o stanie rozwiązania, nie pozwalają ustalić zakresu posiadanej wiedzy ani wykorzystać wszystkich informacji uzyskiwanych podczas bieżącej działalności organizacji.
+Stan dostępności i zgodności rozwiązania cyfrowego zmienia się w całym okresie jego użytkowania. Wpływają na niego między innymi zmiany funkcjonalności, technologii i treści, działania naprawcze, aktualizacje oraz informacje uzyskiwane od użytkowników. Wiedza o stanie rozwiązania wymaga dlatego systematycznego uzyskiwania, aktualizowania i weryfikowania.
 
-Zalecenie zastępuje model oparty na kolejnych niezależnych ocenach systematycznym procesem rozwijania i aktualizowania wiedzy. Informacje pochodzące z różnych źródeł są przetwarzane, odnoszone do wcześniejszych ustaleń i organizowane w rejestrze stanu dostępności i zgodności.
+Pojedyncza ocena lub audyt przedstawia stan rozpoznany w określonym czasie i zakresie. Kolejne niezależne oceny nie zapewniają same w sobie ciągłości wiedzy o stanie rozwiązania, nie pozwalają ustalić zakresu posiadanej wiedzy ani wykorzystać wszystkich informacji uzyskiwanych podczas bieżącej działalności organizacji.
 
-Rejestr umożliwia ustalenie nie tylko tego, co wiadomo o stanie rozwiązania, lecz również zakresu jego rozpoznania. Pozwala odróżnić brak stwierdzonych problemów od posiadania wystarczającej wiedzy o zgodności oraz identyfikować wymagania i części rozwiązania, które nie zostały jeszcze ocenione albo wymagają aktualizacji lub weryfikacji wiedzy.
+Zalecenie zastępuje model oparty na kolejnych niezależnych ocenach systematycznym procesem obserwowania i oceniania stanu. Informacje pochodzące z różnych źródeł są przetwarzane, odnoszone do wcześniejszych ustaleń i organizowane w rejestrze stanu dostępności i zgodności.
 
-Analizowanie zakresu rozpoznania pozwala planować kolejne oceny na podstawie dotychczasowej wiedzy i rzeczywistych potrzeb informacyjnych. Dzięki temu organizacja może stopniowo zwiększać i utrzymywać zakres aktualnej wiedzy, ograniczać niepotrzebne powtarzanie wcześniejszych badań oraz kierować zasoby na ocenę tych wymagań, procesów i części rozwiązania, których rozpoznanie jest najbardziej potrzebne.
+Rejestr umożliwia utrzymywanie aktualnej i udokumentowanej wiedzy o stanie rozwiązania oraz wykorzystywanie jej do podejmowania decyzji i działań służących zapewnianiu dostępności cyfrowej. Wiedza może być wykorzystywana między innymi do planowania i weryfikowania działań naprawczych i doskonalących, zarządzania zmianami, obsługi zgłoszeń użytkowników, odbioru i utrzymania rozwiązań oraz przeglądu i aktualizacji deklaracji dostępności.
 
-W rezultacie organizacja może ustalić, co wiadomo o obecnym stanie rozwiązania i na jakiej podstawie, zidentyfikować luki w wiedzy oraz planować dalsze oceny odpowiednio do rzeczywistych potrzeb informacyjnych.
+Organizacja powinna wiedzieć nie tylko, jaki stan rozwiązania został dotychczas ustalony, lecz również w jakim zakresie posiada podstawy do jego oceny. Analizowanie zakresu rozpoznania pozwala odróżnić brak stwierdzonych problemów od posiadania wystarczającej wiedzy o zgodności oraz identyfikować wymagania i części rozwiązania, które nie zostały jeszcze ocenione albo wymagają aktualizacji lub weryfikacji wiedzy.
+
+Na tej podstawie organizacja może planować kolejne oceny odpowiednio do rzeczywistych potrzeb informacyjnych. Pozwala to stopniowo zwiększać zakres rozpoznania stanu, ograniczać niepotrzebne powtarzanie wcześniejszych badań oraz kierować zasoby na ocenę tych wymagań, procesów i części rozwiązania, których rozpoznanie jest najbardziej potrzebne.
+
+Obserwowanie i ocenianie stanu nie jest zatem celem samym w sobie. Zapewnia organizacji wiedzę potrzebną do podejmowania uzasadnionych decyzji, skutecznego reagowania na problemy oraz planowego utrzymywania i doskonalenia dostępności cyfrowej.
+
 
 ## Powiązane dokumenty
 

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/obserwowanie-i-ocenianie-stanu-dostepnosci-i-zgodnosci-rozwiazan-cyfrowych.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/obserwowanie-i-ocenianie-stanu-dostepnosci-i-zgodnosci-rozwiazan-cyfrowych.md
@@ -1,0 +1,113 @@
+---
+id: obserwowanie-i-ocenianie-stanu-dostepnosci-i-zgodnosci-rozwiazan-cyfrowych
+title: Obserwowanie i ocenianie stanu dostępności i zgodności rozwiązań cyfrowych
+description: Zalecenie dotyczące systematycznego obserwowania i oceniania stanu dostępności i zgodności rozwiązań cyfrowych oraz dokumentowania i wykorzystywania wyników w procesach zapewniania dostępności cyfrowej.
+sidebar_position: 0
+sidebar_label: Zalecenie
+keywords: [dostępność cyfrowa,ocena dostępności,ocena zgodności,obserwowanie stanu,testowanie dostępności,rejestr stanu dostępności i zgodności,]
+tags: [dostępność cyfrowa,ocena dostępności,ocena zgodności,obserwowanie stanu,testowanie dostępności,rejestr stanu dostępności i zgodności,]
+opracowanie: Stefan Wajda
+data_zgloszenia: 29 kwietnia 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+
+## Cel zalecenia
+
+Zapewnienie organizacji aktualnej i udokumentowanej wiedzy o stanie dostępności i zgodności rozwiązań cyfrowych oraz zakresie rozpoznania tego stanu.
+
+## Zalecenie
+
+Organizacja systematycznie obserwuje i ocenia stan dostępności i zgodności rozwiązań cyfrowych w całym okresie ich użytkowania.
+
+Informacje uzyskiwane podczas bieżącej działalności oraz ocen planowych i doraźnych organizacja przetwarza i wykorzystuje do aktualizowania wiedzy o stanie, analizowania zakresu jego rozpoznania oraz planowania dalszych ocen.
+
+## Rekomendacje
+
+### Systematyczne obserwowanie i ocenianie stanu
+
+Organizacja traktuje obserwowanie i ocenianie stanu jako ciągły i iteracyjny proces rozwijania oraz aktualizowania wiedzy o rozwiązaniu cyfrowym.
+
+W procesie wykorzystuje informacje uzyskiwane podczas bieżącej działalności oraz wyniki ocen planowych i doraźnych.
+
+### Prowadzenie ocen planowych i doraźnych
+
+Organizacja prowadzi oceny planowe w celu systematycznego zwiększania i aktualizowania zakresu wiedzy o stanie rozwiązania.
+
+Oceny doraźne prowadzi odpowiednio do zdarzeń i potrzeb informacyjnych wymagających uzyskania, potwierdzenia, uzupełnienia, aktualizacji albo weryfikacji informacji o stanie.
+
+### Pozyskiwanie i wykorzystywanie dokumentacji stanu rozwiązania
+
+Organizacja określa wymagania dotyczące dokumentacji stanu dostępności i zgodności przekazywanej przez wykonawców i dostawców rozwiązań cyfrowych oraz materiałów dowodowych stanowiących podstawę przedstawionych informacji.
+
+Organizacja ocenia zakres, aktualność i wiarygodność otrzymanych informacji i materiałów dowodowych oraz wykorzystuje je do aktualizowania rejestru stanu dostępności i zgodności i ustalania potrzeb dalszego oceniania.
+
+
+### Określanie celu, profilu i zakresu ocen
+
+Przed przeprowadzeniem oceny organizacja określa jej cel oraz zakres wymagań, zakres funkcjonalny i zakres badanej próby.
+
+W przypadku oceny planowej stosuje profil wstępny, rozszerzony albo pogłębiony odpowiednio do celu oceny i aktualnego zakresu udokumentowanej wiedzy.
+
+Profile nie tworzą obowiązkowej sekwencji kolejnych ocen. Organizacja ustala zakres oceny z uwzględnieniem jej celu, aktualnej wiedzy o stanie rozwiązania oraz potrzeb dalszego oceniania.
+
+### Przetwarzanie uzyskanych informacji
+
+Organizacja przetwarza informacje uzyskane podczas obserwowania i oceniania w celu ustalenia ich znaczenia dla wiedzy o stanie rozwiązania.
+
+Rozróżnia czynności służące uzyskaniu informacji, ich wyniki, obserwacje oraz oceny, a nowe informacje odnosi do wcześniejszych ustaleń.
+
+### Prowadzenie rejestru i utrzymywanie aktualności wiedzy
+
+Organizacja prowadzi dla rozwiązania cyfrowego rejestr stanu dostępności i zgodności.
+
+W rejestrze organizuje, aktualizuje i utrzymuje wiedzę o stanie rozwiązania oraz zakresie jego rozpoznania, zachowując podstawę ustaleń, powiązania między informacjami i historię zmian wiedzy.
+
+Organizacja odnosi nowe informacje do wcześniejszych ustaleń i określa, które informacje pozostają aktualne, wymagają weryfikacji albo utraciły aktualność.
+
+### Analizowanie zakresu rozpoznania i planowanie dalszych ocen
+
+Organizacja analizuje zakres rozpoznania stanu w celu ustalenia, jakie wymagania i części rozwiązania zostały rozpoznane, gdzie występują luki w wiedzy oraz które informacje wymagają aktualizacji lub weryfikacji.
+
+Wyniki analizy wykorzystuje do ustalania potrzeb dalszego oceniania i planowania kolejnych ocen.
+
+### Określenie ról i odpowiedzialności
+
+Organizacja określa role i odpowiedzialności związane z obserwowaniem i ocenianiem stanu, planowaniem i przeprowadzaniem ocen, przetwarzaniem uzyskanych informacji, prowadzeniem rejestru oraz analizowaniem zakresu rozpoznania.
+
+Sposób podziału odpowiedzialności dostosowuje do swojej wielkości i struktury, liczby i złożoności rozwiązań cyfrowych oraz przyjętego sposobu organizacji systemu zapewniania dostępności cyfrowej.
+
+## Standardy i podstawy prawne
+
+- [Ustawa z dnia 4 kwietnia 2019 r. o dostępności cyfrowej stron internetowych i aplikacji mobilnych podmiotów publicznych](https://isap.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=WDU20190000848)
+- [Wytyczne dla dostępności treści internetowych (WCAG) 2.1](https://www.w3.org/Translations/WCAG21-pl/)
+- [PN ETSI EN 301 549 v. 3.1.2 Wymagania dotyczące dostępności produktów i usług ICT](https://sklep.pkn.pl/pn-etsi-en-301-549-v3-2-1-2021-09p.html)
+- [W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2.0](https://www.w3.org/TR/wcag-em-2/)
+
+## Uzasadnienie
+
+Stan dostępności i zgodności rozwiązania cyfrowego zmienia się w całym okresie jego użytkowania. Wpływają na niego między innymi zmiany funkcjonalności, technologii i treści, działania naprawcze, aktualizacje oraz informacje uzyskiwane od użytkowników.
+
+Pojedyncza ocena lub audyt przedstawia stan rozpoznany w określonym czasie i zakresie. Kolejne niezależne oceny nie zapewniają same w sobie aktualnej wiedzy o stanie rozwiązania, nie pozwalają ustalić zakresu posiadanej wiedzy ani wykorzystać wszystkich informacji uzyskiwanych podczas bieżącej działalności organizacji.
+
+Zalecenie zastępuje model oparty na kolejnych niezależnych ocenach systematycznym procesem rozwijania i aktualizowania wiedzy. Informacje pochodzące z różnych źródeł są przetwarzane, odnoszone do wcześniejszych ustaleń i organizowane w rejestrze stanu dostępności i zgodności.
+
+Rejestr umożliwia ustalenie nie tylko tego, co wiadomo o stanie rozwiązania, lecz również zakresu jego rozpoznania. Pozwala odróżnić brak stwierdzonych problemów od posiadania wystarczającej wiedzy o zgodności oraz identyfikować wymagania i części rozwiązania, które nie zostały jeszcze ocenione albo wymagają aktualizacji lub weryfikacji wiedzy.
+
+Analizowanie zakresu rozpoznania pozwala planować kolejne oceny na podstawie dotychczasowej wiedzy i rzeczywistych potrzeb informacyjnych. Dzięki temu organizacja może stopniowo zwiększać i utrzymywać zakres aktualnej wiedzy, ograniczać niepotrzebne powtarzanie wcześniejszych badań oraz kierować zasoby na ocenę tych wymagań, procesów i części rozwiązania, których rozpoznanie jest najbardziej potrzebne.
+
+W rezultacie organizacja może ustalić, co wiadomo o obecnym stanie rozwiązania i na jakiej podstawie, zidentyfikować luki w wiedzy oraz planować dalsze oceny odpowiednio do rzeczywistych potrzeb informacyjnych.
+
+## Powiązane dokumenty
+
+- [Profile i zakres ocen stanu dostępności i zgodności](profile-i-zakres-ocen-stanu-dostepnosci-i-zgodnosci)
+- [Procedura obserwowania i oceniania stanu dostępności i zgodności](procedura-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci)
+- [Przetwarzanie wyników obserwowania i oceniania stanu dostępności i zgodności](przetwarzanie-wynikow-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci)
+- [Zasady prowadzenia rejestru stanu dostępności i zgodności](zasady-prowadzenia-rejestru-stanu-dostepnosci-i-zgodnosci.md)
+- [Analiza zakresu rozpoznania stanu dostępności i zgodności](analiza-zakresu-rozpoznania-stanu-dostepnosci-i-zgodnosci)
+
+
+
+
+

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/procedura-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/procedura-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci.md
@@ -1,0 +1,161 @@
+---
+id: procedura-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci
+title: Procedura obserwowania i oceniania stanu dostępności i zgodności
+description: Przykładowa procedura organizowania obserwowania i oceniania stanu dostępności i zgodności rozwiązań cyfrowych oraz aktualizowania i rozwijania wiedzy o ich stanie.
+sidebar_label: Procedura obserwowania i oceniania
+sidebar_position: 2
+keywords: [dostępność cyfrowa,ocena dostępności,ocena zgodności,obserwowanie stanu,testowanie dostępności,scenariusze testów,rejestr stanu dostępności i zgodności,]
+tags: [dostępność cyfrowa,ocena dostępności,ocena zgodności,obserwowanie stanu,testowanie dostępności,scenariusze testów,rejestr stanu dostępności i zgodności,]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+
+---
+
+## Cel dokumentu
+
+Dokument przedstawia przykładową procedurę obserwowania i oceniania stanu dostępności i zgodności rozwiązań cyfrowych.
+
+Procedura łączy obserwowanie stanu, oceny planowe i doraźne, przetwarzanie uzyskanych informacji, aktualizowanie rejestru stanu dostępności i zgodności oraz analizowanie potrzeb dalszego oceniania.
+
+## 1. Zastosowanie procedury
+
+Procedurę stosuje się do organizowania obserwowania i oceniania stanu dostępności i zgodności rozwiązania cyfrowego w całym okresie jego użytkowania.
+
+Jej celem jest utrzymywanie aktualnej i udokumentowanej wiedzy o stanie rozwiązania przez:
+
+- wykorzystywanie informacji uzyskiwanych w bieżącej działalności organizacji;
+- prowadzenie ocen planowych służących systematycznemu rozwijaniu wiedzy;
+- prowadzenie ocen doraźnych w odpowiedzi na określone zdarzenia i potrzeby informacyjne;
+- przetwarzanie uzyskanych informacji i aktualizowanie wiedzy o stanie;
+- analizowanie zakresu rozpoznania i ustalanie potrzeb dalszego oceniania.
+
+Procedurę dostosowuje się do wielkości organizacji, liczby i złożoności rozwiązań cyfrowych oraz sposobu organizacji systemu zapewniania dostępności cyfrowej.
+
+Role i odpowiedzialności związane z obserwowaniem i ocenianiem stanu określa zalecenie „Obserwowanie i ocenianie stanu dostępności i zgodności rozwiązań cyfrowych”.
+
+## 2. Ogólny przebieg procesu
+
+Obserwowanie i ocenianie stanu jest procesem ciągłym i iteracyjnym.
+
+Informacje o stanie rozwiązania są uzyskiwane podczas bieżącej działalności organizacji oraz ocen planowych i doraźnych. Uzyskane informacje są przetwarzane i wykorzystywane do aktualizowania wiedzy zgromadzonej w rejestrze stanu dostępności i zgodności.
+
+Wiedza zgromadzona w rejestrze jest analizowana w celu ustalania zakresu rozpoznania stanu i potrzeb dalszego oceniania. Zdarzenia i potrzeby informacyjne mogą niezależnie prowadzić do przeprowadzenia ocen doraźnych.
+
+Proces obejmuje:
+
+1. uzyskiwanie informacji o stanie rozwiązania;
+2. ustalanie potrzeby przeprowadzenia oceny;
+3. określanie celu i zakresu oceny;
+4. przygotowanie i przeprowadzenie oceny;
+5. przetwarzanie uzyskanych informacji;
+6. aktualizowanie wiedzy o stanie;
+7. analizowanie zakresu rozpoznania i ustalanie potrzeb dalszego oceniania.
+
+Poszczególne działania są podejmowane odpowiednio do źródła informacji, dotychczasowej wiedzy oraz potrzeb dalszego oceniania i nie muszą być każdorazowo wykonywane jako jeden ciąg.
+
+
+## 3. Uzyskiwanie informacji o stanie
+
+Informacje o stanie dostępności i zgodności są uzyskiwane podczas ocen planowych i doraźnych, z dokumentacji i materiałów dowodowych otrzymywanych od wykonawców i dostawców rozwiązań cyfrowych oraz w bieżącej działalności organizacji, między innymi ze zgłoszeń i skarg użytkowników, monitorowania, odbiorów i przeglądów rozwiązań, zmian rozwiązania, działań naprawczych i badań z użytkownikami.
+
+Uzyskana informacja może zostać bezpośrednio przetworzona albo wskazywać potrzebę przeprowadzenia oceny.
+
+
+
+## 4. Ustalanie potrzeby przeprowadzenia oceny
+
+Potrzeba przeprowadzenia oceny może wynikać z planowego rozwijania wiedzy o stanie albo z określonego zdarzenia lub potrzeby informacyjnej.
+
+W zależności od przyczyny przeprowadza się ocenę planową albo doraźną.
+
+### 4.1. Ocena planowa
+
+Ocenę planową przeprowadza się w celu systematycznego zwiększania lub aktualizowania zakresu wiedzy o stanie rozwiązania.
+
+Potrzebę i zakres kolejnej oceny planowej ustala się na podstawie aktualnej wiedzy o stanie oraz wyników analizy zakresu rozpoznania.
+
+### 4.2. Ocena doraźna
+
+Ocenę doraźną przeprowadza się w odpowiedzi na określone zdarzenie albo potrzebę uzyskania informacji.
+
+Przyczyną oceny doraźnej może być w szczególności:
+
+- zgłoszenie lub skarga użytkownika;
+- zmiana rozwiązania;
+- ujawnienie problemu dostępności;
+- potrzeba sprawdzenia skuteczności działania naprawczego;
+- odbiór rozwiązania albo jego części;
+- potrzeba zweryfikowania wcześniejszego ustalenia;
+- uzyskanie informacji wskazującej możliwość występowania problemu.
+
+Zakres oceny doraźnej określa się odpowiednio do zdarzenia lub potrzeby, która spowodowała jej przeprowadzenie.
+
+## 5. Określanie celu i zakresu oceny
+
+Przed przeprowadzeniem oceny określa się jej cel oraz zakres potrzebny do uzyskania informacji odpowiadających temu celowi.
+
+Zakres oceny określa się w trzech wymiarach:
+
+- zakres wymagań;
+- zakres funkcjonalny;
+- zakres badanej próby.
+
+W przypadku oceny planowej określa się również profil oceny.
+
+Przy ustalaniu celu i zakresu wykorzystuje się aktualną wiedzę zgromadzoną w rejestrze stanu dostępności i zgodności oraz, w przypadku ocen planowych, wyniki analizy zakresu rozpoznania.
+
+Szczegółowe zasady określania zakresu i profilu ocen przedstawia załącznik „Profile i zakres ocen stanu dostępności i zgodności”.
+
+## 6. Przygotowanie i przeprowadzenie oceny
+
+Na podstawie ustalonego celu i zakresu oceny:
+
+- wybiera się scenariusze testów i inne metody uzyskania informacji;
+- wskazuje się obiekty tworzące badaną próbę;
+- ustala się sposób przeprowadzenia oceny i dokumentowania jej wyników;
+- zapewnia się potrzebne kompetencje, narzędzia i środowiska testowe.
+
+Ocenę przeprowadza się zgodnie z ustalonym celem i zakresem, dokumentując uzyskane wyniki i materiały dowodowe.
+
+Jeżeli podczas oceny uzyskane zostaną informacje uzasadniające zmianę jej zakresu, zakres może zostać odpowiednio zmodyfikowany. Zmianę dokumentuje się w sposób umożliwiający prawidłową interpretację wyników oceny.
+
+## 7. Przetwarzanie wyników
+
+Informacje uzyskane podczas obserwowania i oceniania przetwarza się w celu ustalenia ich znaczenia dla wiedzy o stanie rozwiązania oraz odniesienia nowych informacji do wcześniejszych ustaleń.
+
+Szczegółowe zasady określa załącznik „Przetwarzanie wyników obserwowania i oceniania stanu dostępności i zgodności”.
+
+## 8. Aktualizowanie wiedzy o stanie
+
+Wyniki obserwowania i oceniania wykorzystuje się do aktualizowania rejestru stanu dostępności i zgodności w sposób umożliwiający ustalenie, co na podstawie dostępnych informacji wiadomo obecnie o stanie rozwiązania.
+
+Szczegółowe zasady określa załącznik „Zasady prowadzenia rejestru stanu dostępności i zgodności”.
+
+## 9. Analizowanie zakresu rozpoznania i ustalanie potrzeb dalszego oceniania
+
+Wiedzę zgromadzoną w rejestrze analizuje się w celu ustalenia zakresu rozpoznania stanu, luk w wiedzy oraz potrzeb dalszego oceniania. Wyniki analizy wykorzystuje się podczas planowania kolejnych ocen.
+
+Szczegółowe zasady określa załącznik „Analiza zakresu rozpoznania stanu dostępności i zgodności”.
+
+
+## 10. Schemat procesu
+
+```mermaid
+flowchart TD
+    A[Uzyskiwanie informacji o stanie] --> B{Czy potrzebna jest ocena?}
+
+    B -->|Nie| F[Przetwarzanie informacji]
+    B -->|Tak| C[Określenie celu i zakresu oceny]
+
+    C --> D[Przygotowanie i przeprowadzenie oceny]
+    D --> F
+
+    F --> G[Aktualizowanie wiedzy w rejestrze]
+    G --> H[Analiza zakresu rozpoznania]
+
+    H -.->|potrzeby dalszego oceniania| C
+
+    G -.-> A
+```

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/profile-i-zakres-ocen-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/profile-i-zakres-ocen-stanu-dostepnosci-i-zgodnosci.md
@@ -1,0 +1,462 @@
+---
+id: profile-i-zakres-ocen-stanu-dostepnosci-i-zgodnosci
+title: Profile i zakres ocen stanu dostępności i zgodności
+description: Zasady rozróżniania ocen planowych i doraźnych, określania zakresu ocen oraz stosowania profilu wstępnego, rozszerzonego i pogłębionego podczas oceniania stanu dostępności i zgodności rozwiązań cyfrowych.
+sidebar_label: Profile i zakres ocen
+sidebar_position: 1
+keywords: [dostępność cyfrowa, ocena dostępności, ocena zgodności, oceny planowe, oceny doraźne, profile oceny, profil wstępny, profil rozszerzony, profil pogłębiony, zakres oceny, scenariusze testów]
+tags: [dostępność cyfrowa, ocena dostępności, ocena zgodności, oceny planowe, oceny doraźne, profile oceny, zakres oceny, scenariusze testów]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+## Cel dokumentu
+
+Dokument określa zasady rozróżniania ocen planowych i doraźnych, ustalania zakresu oceny oraz stosowania profilu wstępnego, rozszerzonego i pogłębionego.
+
+Wyjaśnia również różnicę między profilem oceny planowej a najniższym profilem stosowania scenariusza testu.
+
+## 1. Oceny planowe i doraźne
+
+Organizacja uzyskuje wiedzę o stanie dostępności i zgodności rozwiązania cyfrowego w wyniku różnych ocen prowadzonych w całym okresie jego użytkowania.
+
+Ze względu na sposób określania celu i zakresu wyróżnia się:
+
+1. **oceny planowe**;
+2. **oceny doraźne**.
+
+Rozróżnienie to ma znaczenie dla sposobu ustalania zakresu oceny.
+
+Profile wstępny, rozszerzony i pogłębiony stosuje się do ocen planowych. Zakres ocen doraźnych wynika natomiast z konkretnego zdarzenia lub potrzeby informacyjnej.
+
+### 1.1. Oceny planowe
+
+Oceny planowe są prowadzone w ramach systematycznego rozpoznawania stanu dostępności i zgodności rozwiązania cyfrowego.
+
+Służą w szczególności:
+
+- uzyskaniu pierwszego uporządkowanego obrazu stanu;
+- planowemu zwiększaniu zakresu wiedzy;
+- obejmowaniu oceną kolejnych wymagań dostępności;
+- zwiększaniu zakresu funkcjonalnego ocen;
+- zwiększaniu liczby i reprezentatywności ocenianych obiektów;
+- aktualizowaniu lub weryfikowaniu wcześniejszej wiedzy;
+- pogłębianiu rozpoznania wybranych zagadnień;
+- ocenianiu wymagań dodatkowych.
+
+Zakres oceny planowej określa się z zastosowaniem profilu odpowiedniego do celu oceny i aktualnego zakresu udokumentowanej wiedzy.
+
+### 1.2. Oceny doraźne
+
+Oceny doraźne są podejmowane w związku z określonym zdarzeniem albo potrzebą uzyskania, potwierdzenia, aktualizacji, uzupełnienia lub zweryfikowania informacji o stanie.
+
+Przyczyną oceny doraźnej może być w szczególności:
+
+- zmiana mogąca mieć wpływ na dostępność cyfrową;
+- zgłoszenie lub skarga użytkownika;
+- stwierdzenie możliwego problemu;
+- odbiór rozwiązania albo jego części;
+- zakończenie działania naprawczego lub doskonalącego;
+- rozbieżność między posiadanymi informacjami;
+- potrzeba uzyskania podstawy do podjęcia decyzji.
+
+Zakres oceny doraźnej wynika z jej celu oraz charakteru zdarzenia lub potrzeby.
+
+Ocena doraźna może obejmować jeden test, kilka testów, określony obiekt, grupę obiektów, proces użytkownika, obszar funkcjonalny albo szerszy zakres rozwiązania.
+
+Do ocen doraźnych nie stosuje się wymagań dotyczących profili ocen planowych, minimalnej próby ani planowego zwiększania zakresu rozpoznania stanu.
+
+## 2. Zakres oceny
+
+Zakres oceny określa, czego organizacja zamierza się dowiedzieć oraz jakie części rozwiązania i wymagania zostaną objęte badaniem.
+
+Nie wyznacza go wyłącznie liczba wykonanych testów.
+
+Zakres oceny obejmuje trzy podstawowe wymiary:
+
+1. **zakres wymagań**;
+2. **zakres funkcjonalny**;
+3. **zakres badanej próby**.
+
+Wymiary te należy rozpatrywać łącznie. Ocena może obejmować szeroki zestaw wymagań, ale bardzo wąską próbę obiektów. Może również szczegółowo obejmować określony proces użytkownika, ale tylko wymagania związane z tym procesem.
+
+### 2.1. Zakres wymagań
+
+Zakres wymagań określa, jakie wymagania dostępności podlegają ocenie.
+
+Może obejmować w szczególności:
+
+- mające zastosowanie obowiązkowe wymagania dostępności;
+- wymagania dotychczas nieobjęte oceną;
+- wymagania, których wcześniejsze wyniki wymagają aktualizacji albo weryfikacji;
+- wymagania dodatkowe przyjęte przez organizację;
+- wymagania odpowiednie do określonego problemu, zmiany lub procesu użytkownika.
+
+Wyniku oceny wymagania nie należy uogólniać poza zakres obiektów i funkcji objętych badaniem.
+
+### 2.2. Zakres funkcjonalny
+
+Zakres funkcjonalny określa, jakie części rozwiązania oraz sposoby korzystania z niego podlegają ocenie.
+
+Może obejmować w szczególności:
+
+- obszary funkcjonalne;
+- funkcje;
+- procesy użytkownika;
+- procesy realizacji usług lub załatwiania spraw;
+- komponenty;
+- dokumenty;
+- rodzaje treści;
+- wspólne mechanizmy i szablony.
+
+Zakres funkcjonalny powinien uwzględniać znaczenie poszczególnych funkcji i procesów dla użytkowników.
+
+Ocena pojedynczych stron lub ekranów nie zastępuje oceny procesu użytkownika, jeżeli dostępność rozwiązania zależy od możliwości wykonania całego zadania.
+
+### 2.3. Zakres badanej próby
+
+Zakres badanej próby określa, jakie konkretne obiekty są bezpośrednio oceniane.
+
+Próba może obejmować w szczególności:
+
+- strony;
+- ekrany;
+- widoki;
+- komponenty;
+- elementy;
+- dokumenty;
+- treści;
+- etapy procesów użytkownika.
+
+Przy doborze próby należy uwzględniać nie tylko liczbę obiektów, ale również ich zróżnicowanie i reprezentatywność.
+
+Ocena wielu podobnych obiektów wykorzystujących ten sam szablon może dostarczyć mniej nowej wiedzy niż ocena mniejszej liczby różniących się funkcji, komponentów, procesów lub rodzajów treści.
+
+## 3. Funkcja profili ocen planowych
+
+Profile służą określaniu funkcji i zasad planowania zakresu ocen planowych.
+
+Stosuje się trzy profile:
+
+1. **profil wstępny**;
+2. **profil rozszerzony**;
+3. **profil pogłębiony**.
+
+| Profil          | Podstawowa funkcja                                                                                         |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Wstępny**    | Uzyskanie pierwszego uporządkowanego obrazu stanu w podstawowym zakresie                                   |
+| **Rozszerzony**| Planowe zwiększanie zakresu udokumentowanej wiedzy o stanie i zgodności                                    |
+| **Pogłębiony** | Ocena wymagań dodatkowych oraz zagadnień wymagających specjalistycznej wiedzy lub bardziej złożonych metod |
+
+Profile nie są trzema wielkościami tego samego audytu ani poziomami jakości wykonania oceny.
+
+Profil określa funkcję oceny planowej i sposób ustalania jej zakresu. Nie przesądza o zastosowaniu jednej określonej metody.
+
+Ocena planowa może wykorzystywać między innymi:
+
+- scenariusze testów;
+- testy automatyczne;
+- ocenę ekspercką;
+- audyt;
+- badania z użytkownikami;
+- analizę dokumentacji;
+- inne odpowiednio udokumentowane metody.
+
+## 4. Dobór profilu oceny planowej
+
+Profil oceny planowej dobiera się odpowiednio do:
+
+- celu oceny;
+- zakresu aktualnej i wiarygodnej wiedzy o stanie;
+- wymagań i części rozwiązania dotychczas objętych ocenami;
+- luk w zakresie rozpoznania stanu;
+- znaczenia rozwiązania, funkcji i procesów dla użytkowników;
+- rodzaju i złożoności rozwiązania;
+- przyjętych wymagań dodatkowych;
+- ryzyka związanego z niedostępnością;
+- kompetencji i zasobów potrzebnych do przeprowadzenia oceny.
+
+Profile nie tworzą obowiązkowej sekwencji kolejnych ocen.
+
+Organizacja nie musi rozpoczynać systematycznego oceniania od odrębnej oceny w profilu wstępnym, jeżeli posiada już aktualną, wiarygodną i odpowiednio udokumentowaną wiedzę zapewniającą pierwsze uporządkowane rozpoznanie stanu.
+
+W takim przypadku organizacja ocenia zakres i wiarygodność posiadanych informacji, uzupełnia je w razie potrzeby oraz planuje dalsze oceny odpowiednio do rozpoznanych braków wiedzy.
+
+## 5. Profil wstępny
+
+### 5.1. Funkcja profilu wstępnego
+
+Profil wstępny służy uzyskaniu pierwszego uporządkowanego obrazu stanu dostępności i zgodności rozwiązania cyfrowego, gdy organizacja nie posiada jeszcze wystarczającej i udokumentowanej wiedzy.
+
+Ocena w profilu wstępnym powinna umożliwić:
+
+- rozpoznanie najważniejszych i często występujących problemów dostępności;
+- objęcie oceną głównych obszarów funkcjonalnych;
+- uzyskanie podstawowych informacji o kluczowych procesach użytkownika;
+- utworzenie punktu wyjścia do dalszego obserwowania i oceniania;
+- wskazanie obszarów wymagających dalszej oceny.
+
+Profil wstępny nie określa docelowego zakresu wiedzy o zgodności rozwiązania.
+
+### 5.2. Zakres wymagań
+
+Ocena w profilu wstępnym obejmuje zestaw scenariuszy pozwalających rozpoznać podstawowe problemy dotyczące co najmniej:
+
+- percepcji i prezentacji informacji;
+- struktury, semantyki i orientacji;
+- nawigacji i obsługi przy użyciu klawiatury;
+- widoczności i kolejności fokusu;
+- formularzy, etykiet, instrukcji i komunikatów;
+- podstawowej współpracy z technologiami wspomagającymi;
+- problemów możliwych do wykrycia przy użyciu narzędzi automatycznych.
+
+Scenariusze przeznaczone do pierwszego uporządkowanego rozpoznania stanu mają najniższy profil stosowania „wstępny”.
+
+### 5.3. Zakres funkcjonalny i badana próba
+
+Ocena w profilu wstępnym obejmuje próbę reprezentującą główne części i sposoby korzystania z rozwiązania.
+
+W zależności od rodzaju rozwiązania powinna obejmować co najmniej:
+
+- stronę główną, ekran główny albo inny główny punkt rozpoczęcia korzystania;
+- główne obszary funkcjonalne;
+- kluczowe procesy użytkownika;
+- procesy realizacji usług lub załatwiania spraw, jeżeli występują;
+- reprezentatywny zestaw dodatkowych stron, ekranów, funkcji, dokumentów lub innych obiektów.
+
+Dla strony internetowej lub aplikacji próbę należy rozszerzyć co najmniej o pięć obiektów reprezentujących istotne i zróżnicowane części rozwiązania, o ile jego wielkość i charakter uzasadniają taki zakres.
+
+Dobór próby powinien uwzględniać:
+
+- znaczenie funkcji i procesów dla użytkowników;
+- różnorodność treści, mechanizmów i szablonów;
+- najczęstsze sposoby korzystania z rozwiązania;
+- dostępne informacje o problemach;
+- ryzyko występowania barier.
+
+Ocena w profilu wstępnym powinna zapewnić uporządkowany obraz stanu, a nie jedynie wykonanie określonej liczby testów.
+
+## 6. Profil rozszerzony
+
+### 6.1. Funkcja profilu rozszerzonego
+
+Profil rozszerzony służy planowemu zwiększaniu zakresu aktualnej i udokumentowanej wiedzy o stanie dostępności i zgodności.
+
+Ocena w profilu rozszerzonym wykorzystuje wyniki wcześniejszych obserwacji i ocen. Nie polega na każdorazowym tworzeniu od początku nowego obrazu stanu.
+
+Może służyć:
+
+- objęciu oceną kolejnych obowiązkowych wymagań dostępności;
+- rozszerzeniu oceny na kolejne obszary funkcjonalne;
+- ocenie kolejnych procesów użytkownika;
+- zwiększeniu liczby i zróżnicowania ocenianych obiektów;
+- uzupełnieniu wiedzy w obszarach rozpoznanych częściowo;
+- aktualizacji lub weryfikacji wcześniejszych ustaleń;
+- zwiększeniu reprezentatywności dotychczasowej próby.
+
+Ocena w profilu rozszerzonym powinna prowadzić do możliwego do wykazania zwiększenia zakresu rozpoznania stanu.
+
+### 6.2. Planowanie zakresu
+
+Przed określeniem zakresu oceny w profilu rozszerzonym organizacja ustala:
+
+- jakie wymagania zostały dotychczas ocenione;
+- jakie części rozwiązania objęto ocenami;
+- jakie procesy użytkownika zostały rozpoznane;
+- jakie obiekty tworzyły dotychczasową próbę;
+- które informacje pozostają aktualne i wiarygodne;
+- które informacje wymagają aktualizacji lub weryfikacji;
+- jakie są najważniejsze luki w wiedzy.
+
+Na tej podstawie organizacja wybiera wymagania, obszary funkcjonalne, procesy i obiekty, których ocena dostarczy najbardziej potrzebnej nowej wiedzy.
+
+### 6.3. Rozszerzanie zakresu wymagań
+
+Ocena w profilu rozszerzonym obejmuje kolejne mające zastosowanie wymagania dostępności, które nie zostały dotychczas ocenione albo zostały ocenione w niewystarczającym zakresie.
+
+Scenariusze testów dobiera się odpowiednio do:
+
+- zidentyfikowanych luk w wiedzy;
+- rodzaju i funkcji rozwiązania;
+- stwierdzonych problemów;
+- zmian mogących wpływać na aktualność wcześniejszych ustaleń;
+- znaczenia poszczególnych funkcji i procesów;
+- ryzyka występowania problemów dostępności.
+
+Nie należy określać wartości oceny wyłącznie liczbą dodatkowych scenariuszy. Podstawowym kryterium jest rzeczywiste zwiększenie zakresu rozpoznania stanu.
+
+### 6.4. Rozszerzanie zakresu funkcjonalnego i badanej próby
+
+Ocena w profilu rozszerzonym obejmuje obszary, procesy lub obiekty, które:
+
+- nie były wcześniej oceniane;
+- zostały ocenione tylko częściowo;
+- nie były reprezentowane w dotychczasowej próbie;
+- wykorzystują inne mechanizmy, technologie, szablony lub rodzaje treści;
+- mają szczególne znaczenie dla użytkowników;
+- wiążą się z podwyższonym ryzykiem niedostępności;
+- wymagają aktualizacji lub weryfikacji wcześniejszej wiedzy.
+
+Dobór obiektów powinien zwiększać zakres albo reprezentatywność rozpoznania stanu.
+
+Nie ma potrzeby obejmowania każdą kolejną oceną określonej minimalnej liczby nowych obiektów, jeżeli cel oceny i analiza zakresu rozpoznania uzasadniają inny sposób zwiększenia wiedzy, na przykład objęcie oceną nowego procesu użytkownika lub grupy wymagań.
+
+### 6.5. Dochodzenie do rozpoznania wszystkich obowiązkowych wymagań
+
+Kolejne oceny w profilu rozszerzonym organizacja planuje w sposób umożliwiający docelowo uzyskanie aktualnej i wiarygodnej wiedzy o:
+
+- zgodności ze wszystkimi mającymi zastosowanie obowiązkowymi wymaganiami;
+- stanie głównych i istotnych obszarów funkcjonalnych;
+- dostępności kluczowych procesów użytkownika;
+- stanie reprezentatywnego zakresu stron, ekranów, dokumentów, komponentów i innych obiektów.
+
+Organizacja może uzyskać taką wiedzę w wyniku jednej szerokiej oceny, w tym audytu, albo przez planowe rozszerzanie zakresu kolejnych ocen.
+
+Uzyskanie wiedzy o zgodności ze wszystkimi obowiązkowymi wymaganiami nie kończy obserwowania i oceniania stanu. Wiedza wymaga utrzymywania aktualności odpowiednio do zachodzących zmian i pojawiających się informacji.
+
+## 7. Profil pogłębiony
+
+### 7.1. Funkcja profilu pogłębionego
+
+Profil pogłębiony służy ocenie:
+
+- wymagań wykraczających poza obowiązkowy poziom zgodności;
+- zagadnień wymagających specjalistycznej wiedzy;
+- złożonych komponentów, interakcji i procesów użytkownika;
+- obszarów wymagających zastosowania bardziej złożonych metod;
+- zagadnień wymagających szczegółowej analizy technicznej albo badania z użytkownikami.
+
+Profil pogłębiony nie jest równoznaczny z pełnym audytem całego rozwiązania.
+
+Może dotyczyć wybranego wymagania, funkcji, komponentu, procesu użytkownika, rodzaju treści albo obszaru funkcjonalnego.
+
+### 7.2. Zakres wymagań
+
+Ocena w profilu pogłębionym może obejmować w szczególności:
+
+- kryteria sukcesu WCAG na poziomie AAA;
+- wymagania dodatkowe przyjęte przez organizację;
+- wymagania wynikające ze specyfiki rozwiązania;
+- wymagania wynikające ze szczególnych potrzeb użytkowników;
+- wymagania dotyczące narzędzi autorskich;
+- zagadnienia wymagające pogłębionej interpretacji lub analizy.
+
+### 7.3. Zagadnienia wymagające pogłębionej oceny
+
+Profil pogłębiony może być wykorzystywany między innymi do oceny:
+
+- złożonych komponentów interfejsu;
+- zaawansowanych mechanizmów interakcji;
+- wieloetapowych procesów użytkownika;
+- współpracy z różnymi technologiami wspomagającymi;
+- nietypowych sposobów prezentowania lub wprowadzania informacji;
+- multimediów, wizualizacji i złożonych dokumentów;
+- obszarów o wysokim ryzyku dla użytkowników;
+- problemów wymagających badań z użytkownikami.
+
+Zakres oceny ustala się odpowiednio do zagadnienia wymagającego pogłębionego rozpoznania.
+
+### 7.4. Stosowanie profilu pogłębionego
+
+Profil pogłębiony może być stosowany niezależnie od stopnia objęcia rozwiązania ocenami w profilu rozszerzonym.
+
+Organizacja nie musi najpierw zakończyć oceny wszystkich obowiązkowych wymagań, jeżeli wcześniej powstaje potrzeba pogłębionej oceny określonego komponentu, procesu albo zagadnienia.
+
+Oceny w profilu pogłębionym mogą być prowadzone równolegle z planowym rozszerzaniem wiedzy o zgodności z obowiązkowymi wymaganiami.
+
+## 8. Najniższy profil stosowania scenariusza testu
+
+Każdy scenariusz testu ma przypisany jeden najniższy profil stosowania:
+
+- wstępny;
+- rozszerzony;
+- pogłębiony.
+
+Najniższy profil stosowania określa najwcześniejszy etap planowego rozszerzania zakresu oceny, na którym scenariusz powinien być uwzględniany.
+
+Przy przypisywaniu scenariusza do profilu uwzględnia się w szczególności:
+
+- jego znaczenie dla pierwszego uporządkowanego rozpoznania stanu;
+- rodzaj ocenianego wymagania;
+- to, czy dotyczy wymagania obowiązkowego, czy dodatkowego;
+- złożoność badanego zagadnienia;
+- trudność prawidłowego wykonania testu;
+- zakres wiedzy potrzebnej do interpretacji wyniku;
+- kompetencje potrzebne do przeprowadzenia oceny;
+- potrzebę zastosowania specjalistycznych metod lub narzędzi.
+
+Najniższy profil stosowania nie określa:
+
+- znaczenia wymagania dla użytkowników;
+- możliwego wpływu problemu;
+- priorytetu usunięcia problemu;
+- maksymalnego zakresu zastosowania scenariusza.
+
+Scenariusz o najniższym profilu stosowania „wstępny” może ujawnić problem stanowiący poważną barierę. Scenariusz o najniższym profilu „pogłębiony” może natomiast dotyczyć zagadnienia występującego tylko w określonym, wąskim zakresie.
+
+## 9. Profil oceny a najniższy profil stosowania scenariusza
+
+Profil oceny planowej i najniższy profil stosowania scenariusza testu są pojęciami powiązanymi, ale nie są tożsame.
+
+**Profil oceny**określa funkcję i zasady planowania zakresu całej oceny planowej.
+
+**Najniższy profil stosowania scenariusza**określa miejsce danego scenariusza w systemie planowego rozszerzania zakresu ocen.
+
+W ocenie w profilu wstępnym stosuje się przede wszystkim scenariusze o najniższym profilu stosowania „wstępny”.
+
+W ocenie w profilu rozszerzonym można stosować:
+
+- scenariusze o najniższym profilu „wstępny”, jeżeli potrzebna jest ponowna ocena, aktualizacja wiedzy albo objęcie nimi nowych obiektów;
+- scenariusze o najniższym profilu „rozszerzony”;
+- scenariusze o najniższym profilu „pogłębiony”, jeżeli są potrzebne do osiągnięcia celu oceny.
+
+W ocenie w profilu pogłębionym można stosować scenariusze należące do wszystkich profili.
+
+Profil całej oceny wynika z jej celu i funkcji, a nie z najwyższego profilu zastosowanego scenariusza.
+
+## 10. Stosowanie scenariuszy podczas ocen doraźnych
+
+Oceny doraźne nie są prowadzone w profilu wstępnym, rozszerzonym ani pogłębionym.
+
+Scenariusze testów dobiera się do nich odpowiednio do:
+
+- zdarzenia albo potrzeby uruchamiającej ocenę;
+- pytania, na które ocena ma odpowiedzieć;
+- obiektów, funkcji i procesów, których może dotyczyć problem lub zmiana;
+- wymagań związanych z przedmiotem oceny;
+- poziomu szczegółowości i wiarygodności potrzebnego do podjęcia decyzji.
+
+Ocena doraźna może wykorzystywać:
+
+- jeden scenariusz;
+- kilka scenariuszy o tym samym najniższym profilu stosowania;
+- scenariusze należące do różnych profili;
+- inne odpowiednio dobrane metody.
+
+Zastosowanie scenariusza o najniższym profilu stosowania „pogłębiony” podczas oceny doraźnej nie oznacza przeprowadzenia oceny w profilu pogłębionym.
+
+Przykładowo:
+
+- zgłoszenie problemu z obsługą przycisku za pomocą klawiatury może wymagać wykonania jednego testu o najniższym profilu „wstępny”;
+- zmiana formularza może wymagać zastosowania scenariuszy o najniższym profilu „wstępny” i „rozszerzony”;
+- zmiana złożonego komponentu może wymagać zastosowania scenariuszy o najniższym profilu „pogłębiony”.
+
+## 11. Wykorzystywanie wcześniejszej wiedzy
+
+Przy określaniu profilu i zakresu oceny planowej organizacja wykorzystuje aktualną i wiarygodną wiedzę uzyskaną podczas wcześniejszych obserwacji i ocen.
+
+Kolejna ocena nie powinna bez potrzeby powtarzać wcześniej przeprowadzonych badań. Jej zakres ustala się z uwzględnieniem tego, co już wiadomo o stanie rozwiązania, jakie informacje wymagają aktualizacji lub weryfikacji oraz jakie wymagania i części rozwiązania nie zostały jeszcze ocenione w wystarczającym zakresie.
+
+Szczegółowe zasady identyfikowania luk w wiedzy i ustalania potrzeb dalszej oceny określa załącznik „Analiza zakresu rozpoznania stanu dostępności i zgodności”.
+
+## 12. Dokumentowanie zakresu oceny
+
+Zakres przeprowadzonej oceny dokumentuje się w sposób umożliwiający ustalenie, jakie wymagania, części rozwiązania i obiekty zostały objęte oceną.
+
+W przypadku oceny planowej dokumentuje się również zastosowany profil.
+
+Profil jest właściwością oceny planowej, a najniższy profil stosowania — właściwością scenariusza testu. Nie są one właściwościami obserwacji ani wyniku oceny zgodności.
+
+Szczegółowe zasady dokumentowania ocen i ich zakresu określa załącznik „Zasady prowadzenia rejestru stanu dostępności i zgodności”.

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/profile-i-zakres-ocen-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/profile-i-zakres-ocen-stanu-dostepnosci-i-zgodnosci.md
@@ -41,7 +41,7 @@ Służą w szczególności:
 - planowemu zwiększaniu zakresu wiedzy;
 - obejmowaniu oceną kolejnych wymagań dostępności;
 - zwiększaniu zakresu funkcjonalnego ocen;
-- zwiększaniu liczby i reprezentatywności ocenianych obiektów;
+- zwiększaniu liczby i zróżnicowania ocenianych obiektów oraz reprezentatywności badanej próby;
 - aktualizowaniu lub weryfikowaniu wcześniejszej wiedzy;
 - pogłębianiu rozpoznania wybranych zagadnień;
 - ocenianiu wymagań dodatkowych.
@@ -224,9 +224,7 @@ W zależności od rodzaju rozwiązania powinna obejmować co najmniej:
 - główne obszary funkcjonalne;
 - kluczowe procesy użytkownika;
 - procesy realizacji usług lub załatwiania spraw, jeżeli występują;
-- reprezentatywny zestaw dodatkowych stron, ekranów, funkcji, dokumentów lub innych obiektów.
-
-Dla strony internetowej lub aplikacji próbę należy rozszerzyć co najmniej o pięć obiektów reprezentujących istotne i zróżnicowane części rozwiązania, o ile jego wielkość i charakter uzasadniają taki zakres.
+- co najmniej pięć dodatkowych stron, ekranów, funkcji, dokumentów lub innych obiektów.
 
 Dobór próby powinien uwzględniać:
 
@@ -237,6 +235,7 @@ Dobór próby powinien uwzględniać:
 - ryzyko występowania barier.
 
 Ocena w profilu wstępnym powinna zapewnić uporządkowany obraz stanu, a nie jedynie wykonanie określonej liczby testów.
+
 
 ## 6. Profil rozszerzony
 
@@ -299,9 +298,10 @@ Ocena w profilu rozszerzonym obejmuje obszary, procesy lub obiekty, które:
 - wiążą się z podwyższonym ryzykiem niedostępności;
 - wymagają aktualizacji lub weryfikacji wcześniejszej wiedzy.
 
-Dobór obiektów powinien zwiększać zakres albo reprezentatywność rozpoznania stanu.
+Do czasu uzyskania odpowiedniego zakresu rozpoznania rozwiązania każda kolejna planowa ocena w profilu rozszerzonym powinna zwiększać badaną próbę co najmniej o trzy dodatkowe strony, ekrany, funkcje, dokumenty lub inne obiekty.
 
-Nie ma potrzeby obejmowania każdą kolejną oceną określonej minimalnej liczby nowych obiektów, jeżeli cel oceny i analiza zakresu rozpoznania uzasadniają inny sposób zwiększenia wiedzy, na przykład objęcie oceną nowego procesu użytkownika lub grupy wymagań.
+Dobór dodatkowych obiektów powinien zwiększać zakres rozpoznania stanu albo reprezentatywność badanej próby. Uwzględnia się przy tym dotychczasową wiedzę o rozwiązaniu oraz wyniki analizy zakresu rozpoznania.
+
 
 ### 6.5. Dochodzenie do rozpoznania wszystkich obowiązkowych wymagań
 
@@ -310,7 +310,7 @@ Kolejne oceny w profilu rozszerzonym organizacja planuje w sposób umożliwiają
 - zgodności ze wszystkimi mającymi zastosowanie obowiązkowymi wymaganiami;
 - stanie głównych i istotnych obszarów funkcjonalnych;
 - dostępności kluczowych procesów użytkownika;
-- stanie reprezentatywnego zakresu stron, ekranów, dokumentów, komponentów i innych obiektów.
+- stanie reprezentatywnej próby stron, ekranów, dokumentów, komponentów i innych obiektów.
 
 Organizacja może uzyskać taką wiedzę w wyniku jednej szerokiej oceny, w tym audytu, albo przez planowe rozszerzanie zakresu kolejnych ocen.
 
@@ -400,9 +400,9 @@ Scenariusz o najniższym profilu stosowania „wstępny” może ujawnić proble
 
 Profil oceny planowej i najniższy profil stosowania scenariusza testu są pojęciami powiązanymi, ale nie są tożsame.
 
-**Profil oceny**określa funkcję i zasady planowania zakresu całej oceny planowej.
+**Profil oceny** określa funkcję i zasady planowania zakresu całej oceny planowej.
 
-**Najniższy profil stosowania scenariusza**określa miejsce danego scenariusza w systemie planowego rozszerzania zakresu ocen.
+**Najniższy profil stosowania scenariusza** określa miejsce danego scenariusza w systemie planowego rozszerzania zakresu ocen.
 
 W ocenie w profilu wstępnym stosuje się przede wszystkim scenariusze o najniższym profilu stosowania „wstępny”.
 

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/przetwarzanie-wynikow-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/przetwarzanie-wynikow-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci.md
@@ -1,0 +1,353 @@
+---
+id: przetwarzanie-wynikow-obserwowania-i-oceniania-stanu-dostepnosci-i-zgodnosci
+title: Przetwarzanie wyników obserwowania i oceniania stanu dostępności i zgodności
+description: Zasady przekształcania informacji uzyskanych podczas obserwowania i oceniania w udokumentowaną wiedzę o stanie dostępności i zgodności rozwiązania cyfrowego.
+sidebar_label: Przetwarzanie wyników
+sidebar_position: 3
+keywords: [dostępność cyfrowa, obserwacja, wynik testu, ocena zgodności, ocena wpływu, materiały dowodowe, wiedza o stanie]
+tags: [dostępność cyfrowa, obserwacja, ocena dostępności, ocena zgodności, ocena wpływu, materiały dowodowe]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+## Cel dokumentu
+
+Dokument określa zasady przekształcania informacji uzyskanych podczas obserwowania i oceniania w udokumentowaną wiedzę o stanie dostępności i zgodności rozwiązania cyfrowego.
+
+Wyjaśnia różnicę między czynnością służącą uzyskaniu informacji, jej wynikiem, obserwacją i oceną oraz określa zasady odnoszenia nowych informacji do dotychczasowej wiedzy.
+
+## 1. Od informacji do wiedzy o stanie
+
+Informacje o stanie dostępności i zgodności rozwiązania cyfrowego mogą pochodzić z różnych źródeł i być uzyskiwane za pomocą różnych metod.
+
+Samo wykonanie testu, uzyskanie wyniku narzędzia automatycznego, otrzymanie zgłoszenia użytkownika albo przeprowadzenie audytu nie prowadzi automatycznie do powstania uporządkowanej wiedzy o stanie rozwiązania.
+
+Uzyskane informacje wymagają przetworzenia polegającego na:
+
+1. ustaleniu, czego dotyczy informacja i jaki stan został stwierdzony;
+2. wyodrębnieniu obserwacji;
+3. powiązaniu obserwacji z materiałami dowodowymi;
+4. dokonaniu odpowiednich ocen;
+5. odniesieniu nowych informacji do dotychczasowej wiedzy;
+6. ustaleniu wynikającej z nich zmiany wiedzy o stanie.
+
+Przetwarzanie wyników powinno zachować możliwość ustalenia związku między źródłem informacji, stwierdzonym stanem, podstawą dokonanego ustalenia, oceną oraz wynikającą z nowych informacji zmianą wiedzy.
+
+## 2. Czynność, wynik, obserwacja i ocena
+
+Podczas przetwarzania informacji należy rozróżniać:
+
+- **czynność służącą uzyskaniu informacji**;
+- **wynik czynności**;
+- **obserwację**;
+- **ocenę**.
+
+### 2.1. Czynność służąca uzyskaniu informacji
+
+Czynnością służącą uzyskaniu informacji może być w szczególności:
+
+- wykonanie scenariusza testu;
+- zastosowanie narzędzia automatycznego;
+- przeprowadzenie oceny eksperckiej;
+- przeprowadzenie badania z użytkownikiem;
+- analiza zgłoszenia lub skargi;
+- analiza dokumentacji;
+- zastosowanie innej metody pozwalającej uzyskać informacje o stanie.
+
+Czynność jest sposobem uzyskania informacji. Nie jest obserwacją ani oceną stanu.
+
+### 2.2. Wynik czynności
+
+Wynik dokumentuje przebieg lub rezultat czynności służącej uzyskaniu informacji.
+
+Może nim być w szczególności:
+
+- wynik wykonania scenariusza testu;
+- raport narzędzia automatycznego;
+- wynik badania z użytkownikiem;
+- ustalenie audytu;
+- wynik analizy zgłoszenia;
+- wynik weryfikacji działania naprawczego.
+
+Jedna czynność może nie dostarczyć informacji wymagającej udokumentowania jako nowa obserwacja, potwierdzić wcześniejsze ustalenia albo dostarczyć podstawy do udokumentowania jednej lub wielu obserwacji.
+
+### 2.3. Obserwacja
+
+Obserwacja jest udokumentowaną informacją o stwierdzonym stanie cechy określonego obiektu.
+
+Powinna umożliwiać ustalenie:
+
+- jakiego obiektu dotyczy;
+- jaka cecha została zaobserwowana;
+- jaki stan cechy stwierdzono;
+- kiedy dokonano obserwacji;
+- z jakiego źródła pochodzi informacja;
+- na jakiej podstawie dokonano ustalenia.
+
+Obserwacja opisuje stwierdzony stan, a nie sposób przeprowadzenia badania ani jego ogólny wynik.
+
+Przykład:
+
+> **Wynik testu:** test etykiet pól formularza — wynik negatywny.
+>
+> **Obserwacja:** pole „Adres poczty elektronicznej” w formularzu rejestracji nie ma programowo określonej etykiety.
+
+Pierwszy zapis opisuje wynik czynności. Drugi wskazuje obiekt, cechę i stwierdzony stan, dlatego może stanowić podstawę dalszych ocen i aktualizowania wiedzy.
+
+### 2.4. Ocena
+
+Ocena określa znaczenie stwierdzonego stanu z określonego punktu widzenia.
+
+Ta sama obserwacja może stanowić podstawę różnych ocen.
+
+Przykład:
+
+> **Obserwacja:** pole „Adres poczty elektronicznej” nie ma programowo określonej etykiety.
+>
+> **Ocena zgodności:** niespełnione mające zastosowanie wymaganie dostępności.
+>
+> **Ocena wpływu:** przeszkoda dla użytkowników czytników ekranu.
+
+Obserwacja i jej oceny są odrębnymi, powiązanymi informacjami.
+
+## 3. Wyodrębnianie obserwacji
+
+Informacje uzyskane podczas obserwowania i oceniania analizuje się w celu ustalenia:
+
+- przedmiotu obserwacji;
+- zaobserwowanej cechy;
+- stwierdzonego stanu;
+- czasu dokonania obserwacji;
+- źródła informacji;
+- podstawy dokonanego ustalenia.
+
+Obserwacja powinna opisywać stan na tyle precyzyjnie, aby można było ją zrozumieć i wykorzystać niezależnie od opisu czynności, podczas której stan został stwierdzony.
+
+Nie należy sprowadzać obserwacji do ogólnego wyniku testu, nazwy niespełnionego wymagania ani informacji o występowaniu błędu.
+
+Przedmiot obserwacji powinien być określony odpowiednio do charakteru stwierdzonego stanu. Może nim być pojedynczy element, komponent, dokument, strona, ekran, proces użytkownika, obszar funkcjonalny albo jednoznacznie określona grupa obiektów.
+
+## 4. Jedna czynność a wiele obserwacji
+
+Jedna czynność służąca uzyskaniu informacji może prowadzić do udokumentowania wielu obserwacji.
+
+Jeżeli stwierdzone informacje dotyczą różnych obiektów, cech albo stanów, powinny być rozpatrywane odrębnie.
+
+Przykładowo ocena formularza może wykazać:
+
+- brak programowo określonej etykiety pola;
+- nieprawidłową kolejność fokusu;
+- brak identyfikacji błędu;
+- brak programowego powiązania komunikatu o błędzie z polem.
+
+Każdy z tych stanów może wymagać odrębnej obserwacji, nawet jeżeli został stwierdzony podczas wykonywania jednego scenariusza testu.
+
+Rozdzielenie obserwacji powinno umożliwiać ich niezależne ocenianie, aktualizowanie oraz wykorzystywanie jako podstawy decyzji i działań.
+
+## 5. Stan występujący w wielu obiektach
+
+Ten sam stan może występować w wielu miejscach rozwiązania.
+
+W zależności od charakteru i przyczyny stwierdzonego stanu można:
+
+- udokumentować odrębne obserwacje dotyczące poszczególnych obiektów;
+- udokumentować obserwację dotyczącą jednoznacznie określonej grupy obiektów;
+- udokumentować wspólny stan wynikający z zastosowania tego samego komponentu, szablonu, mechanizmu albo sposobu tworzenia treści.
+
+Sposób wyodrębnienia obserwacji powinien umożliwiać ustalenie rzeczywistego zakresu występowania stanu oraz jego późniejsze aktualizowanie.
+
+Nie należy tworzyć wielu identycznych obserwacji, jeżeli nie zwiększa to wiedzy o stanie ani możliwości jej wykorzystania.
+
+Nie należy również łączyć w jednej obserwacji odrębnych stanów, jeżeli utrudnia to ich ocenianie, aktualizowanie lub powiązanie z decyzjami i działaniami.
+
+## 6. Materiały dowodowe
+
+Każda obserwacja powinna mieć możliwą do wskazania podstawę dowodową.
+
+Materiał dowodowy powinien umożliwiać potwierdzenie stwierdzonego stanu albo sposobu dokonania ustalenia.
+
+Materiałem dowodowym może być w szczególności:
+
+- wynik lub zapis wykonania testu;
+- zrzut ekranu;
+- nagranie;
+- fragment kodu;
+- raport;
+- protokół;
+- wynik narzędzia automatycznego;
+- dokumentacja techniczna;
+- zgłoszenie lub skarga użytkownika;
+- wynik badania z użytkownikami;
+- korespondencja z wykonawcą.
+
+Jedna obserwacja może być powiązana z wieloma materiałami dowodowymi, a jeden materiał dowodowy może stanowić podstawę wielu obserwacji.
+
+Rodzaj i zakres materiałów dowodowych powinien być odpowiedni do charakteru obserwacji oraz sposobu wykorzystania wynikającej z niej wiedzy.
+
+## 7. Ocena zgodności
+
+Ocena zgodności określa relację stwierdzonego stanu do mającego zastosowanie wymagania dostępności.
+
+Przed dokonaniem oceny należy ustalić:
+
+- jakie wymaganie ma zastosowanie;
+- jakiego obiektu albo zakresu dotyczy ocena;
+- czy posiadane informacje i materiały dowodowe są wystarczające do dokonania oceny.
+
+Wynik oceny zgodności może wskazywać:
+
+- spełnione;
+- niespełnione;
+- nie dotyczy;
+- brak wystarczających danych do dokonania oceny.
+
+Wynik odnosi się do wymagania oraz zakresu, dla którego uzyskano wystarczające informacje.
+
+Nie należy automatycznie uogólniać wyniku poza oceniony zakres.
+
+Jedna obserwacja może stanowić podstawę oceny zgodności z więcej niż jednym wymaganiem. Jedno wymaganie może być oceniane na podstawie wielu obserwacji.
+
+## 8. Ocena wpływu na użytkowników
+
+Ocena wpływu określa znaczenie stwierdzonego stanu dla możliwości korzystania z rozwiązania.
+
+Przy ocenie wpływu można uwzględniać w szczególności:
+
+- strategie korzystania z rozwiązania;
+- użytkowników, których może dotyczyć stwierdzony stan;
+- znaczenie funkcji lub procesu;
+- częstotliwość występowania problemu;
+- możliwość wykonania zadania;
+- możliwość zastosowania sposobu obejścia problemu.
+
+Wynik oceny wpływu dokumentuje się według przyjętej w SZDC skali:
+
+- brak istotnego wpływu;
+- kłopot;
+- przeszkoda;
+- bariera.
+
+Ocena wpływu jest odrębna od oceny zgodności.
+
+Niezgodności z tym samym wymaganiem mogą mieć różny wpływ zależnie od miejsca, funkcji i kontekstu ich występowania. Stan zgodny z obowiązkowymi wymaganiami może natomiast ujawniać problem istotny dla użytkowników i wymagający uwagi organizacji.
+
+## 9. Odnoszenie nowych informacji do dotychczasowej wiedzy
+
+Nowe informacje należy odnosić do wiedzy uzyskanej wcześniej.
+
+Organizacja ustala, czy nowa informacja:
+
+- potwierdza wcześniejsze ustalenie;
+- aktualizuje wiedzę o stanie;
+- uzupełnia brakujące informacje;
+- podważa aktualność wcześniejszego ustalenia;
+- wskazuje zmianę stanu;
+- wskazuje potrzebę dodatkowej lub ponownej oceny.
+
+Odnoszenie nowych informacji do wcześniejszej wiedzy zapobiega tworzeniu kolejnych niezależnych zbiorów wyników i umożliwia utrzymywanie rozwijanego obrazu stanu rozwiązania.
+
+## 10. Dokumentowanie nowego stanu i zmiany stanu
+
+Nową obserwację dokumentuje się, jeżeli:
+
+- stwierdzono wcześniej nieudokumentowany stan;
+- nowa informacja dotyczy innego obiektu lub cechy;
+- ponowna ocena wykazała zmianę stanu;
+- zachowanie odrębnego zapisu jest potrzebne do odtworzenia historii zmian.
+
+Jeżeli nowa informacja wskazuje zmianę wcześniej udokumentowanego stanu:
+
+1. dokumentuje się nową obserwację;
+2. wiąże się ją z wcześniejszym ustaleniem;
+3. wskazuje się podstawę stwierdzenia nowego stanu;
+4. dokonuje się potrzebnych ocen;
+5. aktualizuje się wiedzę o obecnym stanie.
+
+Wcześniejszej obserwacji nie nadpisuje się nowym stanem. Pozostaje ona historycznym zapisem ustalenia dokonanego w określonym czasie.
+
+## 11. Potwierdzanie wcześniejszego stanu
+
+Ponowne wykonanie testu albo zastosowanie innej metody może potwierdzić stan udokumentowany wcześniej.
+
+W takim przypadku należy zachować możliwość ustalenia:
+
+- co zostało ponownie ocenione;
+- za pomocą jakiej metody;
+- na jakiej podstawie potwierdzono wcześniejsze ustalenie;
+- kiedy dokonano potwierdzenia.
+
+Samo potwierdzenie wcześniejszego stanu nie wymaga tworzenia kolejnej identycznej obserwacji, jeżeli wynik ponownej oceny i jego podstawa mogą zostać jednoznacznie powiązane z wcześniejszym ustaleniem.
+
+Nową obserwację należy udokumentować, jeżeli jest to potrzebne do zachowania historii zmian albo prawidłowego przedstawienia zakresu przeprowadzonej oceny.
+
+## 12. Informacje niewystarczające do dokonania oceny
+
+Nie każda uzyskana informacja umożliwia jednoznaczne ustalenie stanu albo dokonanie oceny.
+
+Informacja może w szczególności:
+
+- wskazywać możliwość występowania problemu;
+- być niepełna;
+- pochodzić ze źródła wymagającego weryfikacji;
+- nie pozwalać na jednoznaczne ustalenie stanu;
+- nie dostarczać wystarczającej podstawy do oceny zgodności lub wpływu.
+
+W takim przypadku informację należy zachować odpowiednio do jej znaczenia oraz wskazać potrzebę jej weryfikacji lub przeprowadzenia dalszej oceny.
+
+Brak wystarczających danych nie stanowi podstawy do uznania wymagania za spełnione.
+
+Informacja, której nie można jeszcze przekształcić w jednoznaczną obserwację lub ocenę, nie powinna być odrzucana, jeżeli może mieć znaczenie dla wiedzy o stanie rozwiązania.
+
+## 13. Aktualizowanie wiedzy o stanie
+
+Po przetworzeniu nowych informacji należy ustalić, w jaki sposób wpływają one na dotychczasową wiedzę o stanie rozwiązania.
+
+W zależności od uzyskanych wyników może być potrzebne:
+
+- udokumentowanie nowej obserwacji;
+- powiązanie nowej informacji z wcześniejszym ustaleniem;
+- udokumentowanie oceny zgodności lub wpływu;
+- powiązanie obserwacji i ocen z materiałami dowodowymi;
+- potwierdzenie aktualności wcześniejszej wiedzy;
+- wskazanie, że wcześniejsze ustalenie wymaga weryfikacji;
+- wskazanie utraty aktualności wcześniejszego ustalenia;
+- zaktualizowanie wiedzy o obecnym stanie;
+- wskazanie potrzeby dalszej oceny.
+
+Przetworzenie wyników kończy się ustaleniem, co na podstawie uzyskanych informacji można obecnie wiarygodnie powiedzieć o stanie dostępności i zgodności rozwiązania.
+
+Szczegółowe zasady organizowania, aktualizowania i utrzymywania wiedzy określa załącznik „Zasady prowadzenia rejestru stanu dostępności i zgodności”.
+
+## 14. Schemat przetwarzania wyników
+
+```mermaid
+flowchart TD
+    A[Źródło informacji lub czynność] --> B[Wynik]
+    B --> C[Ustalenie obiektu, cechy i stwierdzonego stanu]
+    C --> D[Obserwacja]
+    D --> E[Powiązanie z materiałami dowodowymi]
+
+    E --> F[Ocena zgodności]
+    E --> G[Ocena wpływu]
+
+    F --> H[Odniesienie do wcześniejszej wiedzy]
+    G --> H
+
+    H --> I{Znaczenie nowej informacji}
+
+    I -->|Potwierdza| J[Potwierdzenie wcześniejszego ustalenia]
+    I -->|Aktualizuje| K[Aktualizacja wiedzy o stanie]
+    I -->|Uzupełnia| L[Uzupełnienie wiedzy]
+    I -->|Wskazuje zmianę| M[Udokumentowanie nowego stanu]
+    I -->|Podważa aktualność| N[Oznaczenie potrzeby weryfikacji]
+    I -->|Niewystarczająca| O[Wskazanie potrzeby dalszej oceny]
+
+    J --> P[Aktualizacja wiedzy o stanie]
+    K --> P
+    L --> P
+    M --> P
+    N --> P
+    O --> P
+```

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-rezygnacji-z-prac-nad-zaleceniem-okresowa-ocena-stanu.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-rezygnacji-z-prac-nad-zaleceniem-okresowa-ocena-stanu.md
@@ -3,7 +3,7 @@ id: uzasadnienie-rezygnacji-z-prac-nad-zaleceniem-okresowa-ocena-stanu
 title: Uzasadnienie rezygnacji z kontynuowania prac nad projektem zalecenia Okresowa ocena stanu dostępności i zgodności
 description: Materiał doboczy, wyjaśnia propozycję wycofania projektu Procedura oceny dostępności  
 sidebar_label: Uzasadnienie 2
-sidebar_position: 7
+sidebar_position: 8
 keywords: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
 tags: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
 opracowanie: Stefan Wajda

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-rezygnacji-z-prac-nad-zaleceniem-okresowa-ocena-stanu.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-rezygnacji-z-prac-nad-zaleceniem-okresowa-ocena-stanu.md
@@ -1,0 +1,159 @@
+---
+id: uzasadnienie-rezygnacji-z-prac-nad-zaleceniem-okresowa-ocena-stanu
+title: Uzasadnienie rezygnacji z kontynuowania prac nad projektem zalecenia Okresowa ocena stanu dostępności i zgodności
+description: Materiał doboczy, wyjaśnia propozycję wycofania projektu Procedura oceny dostępności  
+sidebar_label: Uzasadnienie 2
+sidebar_position: 7
+keywords: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
+tags: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+:::danger Wyjaśnienie
+
+Ten materiał ma charakter roboczy, służy jedynie wyjaśnieniu, dlaczego proponuje się wycofanie zaakceptowanego wcześniej projektu **Okresowa ocena stanu dostępności i zgodności**
+
+:::
+
+
+## Uzasadnienie rezygnacji z kontynuowania prac nad projektem zalecenia
+
+Projekt zalecenia „Okresowa ocena stanu zgodności rozwiązań cyfrowych i aktualizacja deklaracji dostępności” powstał podczas prac nad przebudową wcześniejszego zalecenia dotyczącego przeglądu i aktualizacji deklaracji dostępności.
+
+Prace te ujawniły problem bardziej podstawowy. Wiarygodne przeglądanie i aktualizowanie deklaracji dostępności wymaga posiadania przez organizację aktualnej i udokumentowanej wiedzy o stanie dostępności i zgodności strony internetowej lub aplikacji mobilnej. Brakowało jednak zalecenia określającego, w jaki sposób organizacja powinna systematycznie uzyskiwać, aktualizować i rozwijać taką wiedzę.
+
+Z tego powodu prace nad nową wersją zalecenia dotyczącego deklaracji dostępności zostały czasowo przerwane, a podjęto prace nad projektem „Okresowa ocena stanu zgodności rozwiązań cyfrowych i aktualizacja deklaracji dostępności”.
+
+Projekt opierał się na założeniu, że organizacja nie powinna traktować oceny dostępności jako pojedynczego, niezależnego badania. Powinna wykorzystywać wyniki wcześniejszych ocen, informacje o zmianach, zgłoszenia użytkowników i inne dostępne źródła oraz stopniowo rozwijać wiedzę o stanie zgodności rozwiązania.
+
+Pierwsza ocena miała zapewniać minimalny zakres rozpoznania stanu, a kolejne okresowe oceny wykorzystywać wcześniejsze wyniki i stopniowo obejmować kolejne wymagania dostępności, obszary funkcjonalne oraz strony, ekrany, funkcje i procesy. Wiedza miała być dokumentowana w aktualizowanym raporcie zgodności pełniącym funkcję rejestru wiedzy o stanie rozwiązania.
+
+Dalsze prace nad projektem wykazały jednak, że koncepcja okresowej oceny nie rozwiązuje w pełni zidentyfikowanego problemu.
+
+## Odejście od okresowej oceny jako podstawowego mechanizmu poznawania stanu
+
+Najważniejszą przyczyną rezygnacji z kontynuowania projektu jest zmiana sposobu rozumienia procesu poznawania stanu dostępności i zgodności rozwiązania cyfrowego.
+
+Projekt stanowił istotny krok w stosunku do modelu opartego na kolejnych, niezależnych badaniach lub audytach. Zakładał wykorzystywanie wcześniejszych wyników, integrowanie informacji pochodzących z różnych źródeł oraz stopniowe rozszerzanie wiedzy o stanie rozwiązania.
+
+Nadal jednak czynił okresową ocenę głównym mechanizmem organizującym poznawanie stanu.
+
+W toku dalszych prac uznano, że organizacja uzyskuje informacje o stanie dostępności i zgodności nie tylko podczas okresowych badań. Nowa wiedza powstaje również w związku ze zmianami rozwiązania, zgłoszeniami użytkowników, kontrolą bieżącą, odbiorami, działaniami naprawczymi, wynikami testów automatycznych i wieloma innymi zdarzeniami.
+
+Nie każda potrzeba uzyskania lub aktualizacji wiedzy wymaga przeprowadzenia rozbudowanej oceny. Niekiedy wystarczające jest wykonanie jednego lub kilku odpowiednio dobranych testów.
+
+Z tego powodu przyjęto rozróżnienie między ciągłym obserwowaniem stanu a ocenami podejmowanymi w określonym celu.
+
+Oceny mogą być planowe, służące systematycznemu uzyskiwaniu, aktualizowaniu, rozszerzaniu i pogłębianiu wiedzy, albo doraźne, podejmowane w związku z konkretnym zdarzeniem lub potrzebą informacyjną.
+
+W nowym modelu podstawowym mechanizmem nie są zatem kolejne okresowe oceny, lecz:
+
+- ciągłe obserwowanie stanu;
+- przeprowadzanie ocen planowych i doraźnych odpowiednio do potrzeb;
+- wykorzystywanie wcześniejszej wiedzy;
+- dokumentowanie i przetwarzanie wyników;
+- aktualizowanie, rozszerzanie i pogłębianie wiedzy o stanie.
+
+Koncepcja ta została rozwinięta w projekcie zalecenia „Obserwowanie i ocenianie stanu dostępności i zgodności”.
+
+## Rozwinięcie koncepcji zakresu ocen
+
+Istotnej zmianie uległa również koncepcja stopniowego rozszerzania zakresu ocen.
+
+W projekcie „Okresowa ocena stanu zgodności…” zakładano, że pierwsze badanie obejmuje minimalny zakres, a każda kolejna okresowa ocena służy stopniowemu zwiększaniu liczby ocenianych wymagań, obszarów funkcjonalnych i obiektów.
+
+Dalsze prace wykazały potrzebę rozdzielenia dwóch różnych sytuacji.
+
+Oceny planowe rzeczywiście powinny służyć systematycznemu rozwijaniu wiedzy o stanie rozwiązania. W tym celu opracowano profile wstępny, rozszerzony i pogłębiony.
+
+Profil wstępny służy uzyskaniu pierwszego uporządkowanego rozpoznania stanu. Profil rozszerzony pozwala planowo zwiększać zakres wiedzy przez obejmowanie oceną kolejnych wymagań, obszarów funkcjonalnych i obiektów. Profil pogłębiony służy badaniu zagadnień wymagających specjalistycznej wiedzy, złożonych metod albo wykraczających poza minimalne wymagania zgodności.
+
+Inną funkcję pełnią oceny doraźne. Są podejmowane w celu odpowiedzi na konkretną potrzebę informacyjną i mogą obejmować jeden lub kilka testów. Nie stosuje się do nich wymagania systematycznego rozszerzania zakresu rozpoznania ani profili ocen planowych.
+
+Rozróżnienie to pozwoliło zachować wartościową ideę stopniowego rozwijania wiedzy, a jednocześnie uniknąć wymagania, aby każda kolejna ocena była szersza od poprzedniej.
+
+## Zastąpienie raportu zgodności rejestrem stanu dostępności i zgodności
+
+Dalszego rozwinięcia wymagała również zaproponowana w projekcie koncepcja raportu zgodności.
+
+Projekt odchodził już od rozumienia raportu jako dokumentu tworzonego po zakończeniu pojedynczego badania. Raport zgodności miał być wersjonowanym i aktualizowanym rejestrem wiedzy o stanie rozwiązania.
+
+Dalsze prace wykazały jednak, że pojęcie raportu nie odpowiada funkcji, jaką miał pełnić ten mechanizm.
+
+Raport jest sposobem przedstawienia informacji dla określonego celu i na określony moment. Nie powinien być podstawowym miejscem przechowywania i przetwarzania wiedzy o stanie rozwiązania.
+
+Dlatego koncepcja raportu zgodności została zastąpiona koncepcją rejestru stanu dostępności i zgodności.
+
+Podstawową jednostką rejestru jest obserwacja, czyli udokumentowana informacja o stwierdzonym stanie cechy określonego obiektu.
+
+Wyniki testów, ocen planowych i doraźnych, zgłoszeń użytkowników, weryfikacji działań naprawczych oraz innych źródeł służą tworzeniu i aktualizowaniu wiedzy utrzymywanej w rejestrze.
+
+Na podstawie informacji zgromadzonych w rejestrze organizacja może ustalać aktualny stan, analizować historię zmian, oceniać zakres rozpoznania stanu oraz tworzyć potrzebne zestawienia i raporty.
+
+Zmiana ta oznacza przejście od prowadzenia aktualizowanego dokumentu o stanie zgodności do utrzymywania uporządkowanej wiedzy o stanie rozwiązania.
+
+## Rozwinięcie koncepcji zakresu rozpoznania stanu
+
+Projekt „Okresowa ocena stanu zgodności…” zawierał założenie, że organizacja powinna stopniowo zwiększać zakres wiedzy o stanie rozwiązania.
+
+Dalsze prace pozwoliły rozwinąć tę ideę i wyodrębnić pojęcie zakresu rozpoznania stanu.
+
+Organizacja powinna wiedzieć nie tylko, jaki stan został stwierdzony, ale również w jakim zakresie posiada aktualne i wystarczające podstawy do jego ustalenia.
+
+Brak informacji o problemach nie oznacza bowiem zgodności rozwiązania. Może wynikać z tego, że określone wymagania, obszary funkcjonalne, procesy lub obiekty nie zostały dotychczas ocenione.
+
+Analizowanie zakresu rozpoznania pozwala ustalić:
+
+- co organizacja już wie o stanie rozwiązania;
+- czego jeszcze nie wie;
+- które informacje wymagają aktualizacji lub weryfikacji;
+- co powinno zostać objęte kolejnymi ocenami.
+
+Na tej podstawie możliwe jest planowanie kolejnych ocen odpowiednio do rzeczywistych potrzeb informacyjnych zamiast powtarzania wcześniejszych badań.
+
+## Powstanie nowego pakietu zalecenia
+
+W wyniku dalszych prac pierwotny projekt został stopniowo przekształcony w znacznie szerszą i bardziej spójną koncepcję.
+
+Pakiet „Obserwowanie i ocenianie stanu dostępności i zgodności” obejmuje obecnie:
+
+- ciągłe obserwowanie stanu;
+- oceny planowe i doraźne;
+- profile wstępny, rozszerzony i pogłębiony;
+- planowanie i przeprowadzanie ocen;
+- dobór zakresu i scenariuszy testów;
+- bibliotekę scenariuszy testów;
+- dokumentowanie i przetwarzanie wyników;
+- prowadzenie rejestru stanu dostępności i zgodności;
+- analizowanie zakresu rozpoznania stanu;
+- identyfikowanie braków wiedzy;
+- planowanie kolejnych ocen.
+
+Nowe zalecenie nie jest zatem kolejną wersją projektu dotyczącego okresowej oceny.
+
+Stanowi rezultat zasadniczej zmiany sposobu rozwiązania problemu, który doprowadził do powstania wcześniejszego projektu.
+
+## Znaczenie projektu dla dalszych prac
+
+Rezygnacja z kontynuowania projektu nie oznacza zakwestionowania jego wartości.
+
+Projekt odegrał istotną rolę w rozwoju koncepcji systemu zapewniania dostępności cyfrowej.
+
+To w nim sformułowano między innymi założenia dotyczące:
+
+- wykorzystywania wyników wcześniejszych ocen;
+- integrowania informacji pochodzących z różnych źródeł;
+- stopniowego rozszerzania wiedzy o stanie rozwiązania;
+- odejścia od raportu jako rezultatu pojedynczego badania;
+- utrzymywania aktualizowanego zasobu wiedzy o stanie zgodności.
+
+Dalsze prace pozwoliły rozwinąć te założenia, usunąć ich ograniczenia i osadzić je w szerszej architekturze systemu zapewniania dostępności cyfrowej.
+
+Zakończenie prac nad nowym pakietem „Obserwowanie i ocenianie stanu dostępności i zgodności” pozwala jednocześnie powrócić do przebudowy wcześniejszego zalecenia dotyczącego przeglądu i aktualizacji deklaracji dostępności.
+
+Nowa wersja tego zalecenia może zostać oparta na jasno określonej zasadzie: organizacja utrzymuje aktualną i udokumentowaną wiedzę o stanie dostępności i zgodności w ramach odrębnego mechanizmu obserwowania i oceniania stanu, natomiast proces przeglądu i aktualizacji deklaracji korzysta z tej wiedzy.
+
+Z tych powodów proponuje się zakończenie prac nad projektem zalecenia „Okresowa ocena stanu zgodności rozwiązań cyfrowych i aktualizacja deklaracji dostępności” i zastąpienie go pakietem „Obserwowanie i ocenianie stanu dostępności i zgodności”, a następnie kontynuowanie prac nad nową wersją wcześniejszego zalecenia dotyczącego przeglądu i aktualizacji deklaracji dostępności.

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-wycofania-projektu-procedura-oceny-dostepnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-wycofania-projektu-procedura-oceny-dostepnosci.md
@@ -1,0 +1,64 @@
+---
+id: uzasadnienie-wycofania-projektu-procedura-oceny-dostepnosci
+title: Uzasadnienie wycofania projektu zalecenia Procedura oceny dostępności
+description: Materiał doboczy, wyjaśnia propozycję wycofania projektu Procedura oceny dostępności  
+sidebar_label: Uzasadnienie 1
+sidebar_position: 6
+keywords: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
+tags: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+:::danger Wyjaśnienie
+
+Ten materiał ma charakter roboczy, służy jedynie wyjaśnieniu, dlaczego proponuje się wycofanie zaakceptowanego wcześniej projektu Procedura oceny dostępności 
+
+:::
+
+
+Projekt zalecenia w sprawie określenia procedury badania i oceniania dostępności cyfrowej stron internetowych i aplikacji mobilnych powstał na wcześniejszym etapie prac Sieci Dostępności Cyfrowej. Jego celem było uporządkowanie sposobu przygotowania, przeprowadzania i dokumentowania badań dostępności cyfrowej oraz zapewnienie organizacjom publicznym praktycznej procedury postępowania.
+
+Projekt wraz z załącznikami został wstępnie zaakceptowany przez Sieć. Dalsze prace nad zaleceniami dotyczącymi oceniania stanu dostępności i zgodności oraz nad koncepcją systemu zapewniania dostępności cyfrowej doprowadziły jednak do istotnej zmiany podejścia do tego zagadnienia.
+
+Wcześniejszy projekt koncentruje się na pojedynczym badaniu dostępności cyfrowej. Określa sposób jego przygotowania, przeprowadzenia, udokumentowania wyników i sformułowania oceny. Tym samym, mimo uporządkowania samego procesu badawczego, pozostaje osadzony w dominującym obecnie modelu, w którym podstawowym sposobem poznawania stanu dostępności rozwiązania są kolejne, odrębne badania lub audyty.
+
+W toku dalszych prac Sieci model ten został poddany krytycznej analizie. Uznano, że pojedyncze, powtarzane od czasu do czasu badania nie tworzą skutecznego mechanizmu zarządzania dostępnością cyfrową. Każde kolejne badanie może ponownie obejmować te same obszary i wymagania, powtarzać wcześniej wykonane czynności oraz prowadzić do powstawania kolejnych raportów, które nie tworzą trwałej i systematycznie rozwijanej wiedzy o stanie rozwiązania.
+
+Nowe zalecenie „Obserwowanie i ocenianie stanu dostępności i zgodności” opiera się na innym założeniu. Przedmiotem organizacji nie jest pojedyncze badanie, lecz ciągły proces obserwowania i oceniania stanu rozwiązania cyfrowego.
+
+W nowym podejściu organizacja:
+
+- prowadzi ciągłe obserwowanie stanu dostępności i zgodności;
+- przeprowadza oceny planowe i doraźne odpowiednio do potrzeb i zdarzeń;
+- wykorzystuje wyniki wcześniejszych obserwacji i ocen;
+- dokumentuje wiedzę w rejestrze stanu dostępności i zgodności;
+- ustala nie tylko stan rozwiązania, lecz również zakres jego rozpoznania;
+- identyfikuje braki i nieaktualne informacje;
+- planuje kolejne oceny na podstawie posiadanej wiedzy i stwierdzonych potrzeb;
+- stopniowo rozszerza i pogłębia zakres rozpoznania stanu;
+- wykorzystuje zgromadzoną wiedzę w innych procesach systemu zapewniania dostępności cyfrowej.
+
+Zmianie ulega zatem nie tylko procedura prowadzenia badań, lecz cały sposób organizowania procesu poznawania i oceniania stanu dostępności i zgodności.
+
+Wcześniejszy projekt odpowiadał przede wszystkim na pytanie:
+
+> **Jak prawidłowo przeprowadzić badanie dostępności cyfrowej?**
+
+Nowe zalecenie odpowiada na pytanie szersze:
+
+> **Jak organizacja powinna systematycznie obserwować, oceniać i rozwijać wiedzę o stanie dostępności i zgodności swoich rozwiązań cyfrowych?**
+
+W nowym modelu pojedyncze badanie pozostaje jednym ze sposobów pozyskiwania wiedzy. Nie stanowi jednak samodzielnego, nadrzędnego procesu wymagającego odrębnego zalecenia. Przygotowanie i przeprowadzanie ocen zostało włączone do szerszego mechanizmu obejmującego obserwowanie stanu, planowanie ocen, dobór zakresu i metod, stosowanie scenariuszy testów, przetwarzanie wyników, prowadzenie rejestru oraz analizowanie zakresu posiadanej wiedzy.
+
+Nowe zalecenie wraz z załącznikami przejmuje zatem funkcje wcześniejszego projektu, a jednocześnie osadza je w szerszej i bardziej spójnej architekturze systemu zapewniania dostępności cyfrowej.
+
+Utrzymywanie obu zaleceń prowadziłoby do powielania regulowanych zagadnień oraz do współistnienia dwóch odmiennych koncepcji oceniania dostępności: modelu skoncentrowanego na pojedynczym badaniu i modelu opartego na ciągłym obserwowaniu, ocenianiu oraz rozwijaniu udokumentowanej wiedzy o stanie rozwiązania.
+
+Wycofanie wcześniejszego projektu nie oznacza zakwestionowania wartości wykonanych prac. Projekt odegrał istotną rolę w uporządkowaniu problematyki badania dostępności cyfrowej, a część wypracowanych w nim rozwiązań została wykorzystana i rozwinięta podczas opracowywania nowego zalecenia oraz jego załączników.
+
+Zmiana jest rezultatem rozwoju koncepcji systemu zapewniania dostępności cyfrowej i przejścia od regulowania pojedynczych czynności badawczych do projektowania trwałego mechanizmu obserwowania, oceniania i wykorzystywania wiedzy o stanie dostępności i zgodności.
+
+Z tych powodów proponuje się wycofanie projektu zalecenia w sprawie określenia procedury badania i oceniania dostępności cyfrowej stron internetowych i aplikacji mobilnych oraz zastąpienie go zaleceniem „Obserwowanie i ocenianie stanu dostępności i zgodności” wraz z jego załącznikami.

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-wycofania-projektu-procedura-oceny-dostepnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/uzasadnienie-wycofania-projektu-procedura-oceny-dostepnosci.md
@@ -3,7 +3,7 @@ id: uzasadnienie-wycofania-projektu-procedura-oceny-dostepnosci
 title: Uzasadnienie wycofania projektu zalecenia Procedura oceny dostępności
 description: Materiał doboczy, wyjaśnia propozycję wycofania projektu Procedura oceny dostępności  
 sidebar_label: Uzasadnienie 1
-sidebar_position: 6
+sidebar_position: 7
 keywords: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
 tags: [dostępność cyfrowa, stan dostępności, stan zgodności, zakres rozpoznania stanu, luka informacyjna, plan ocen, rejestr stanu dostępności i zgodności]
 opracowanie: Stefan Wajda

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/wykorzystywanie-narzedzi-automatycznych-do-obserwowania-i-oceniania-stanu-dostepnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/wykorzystywanie-narzedzi-automatycznych-do-obserwowania-i-oceniania-stanu-dostepnosci.md
@@ -1,0 +1,581 @@
+---
+id: wykorzystywanie-narzedzi-automatycznych-do-obserwowania-i-oceniania-stanu-dostepnosci
+title: Wykorzystywanie narzędzi automatycznych do obserwowania i oceniania stanu dostępności
+description: Zasady wykorzystywania automatycznych analiz i systemów monitorujących do wykrywania problemów, wspierania oceniania oraz podejmowania i weryfikowania działań służących zapewnianiu i doskonaleniu dostępności cyfrowej.
+sidebar_label: Narzędzia automatyczne
+sidebar_position: 6
+keywords: [narzędzia automatyczne,automatyczne testowanie,automatyczna analiza,monitorowanie dostępności,skanowanie dostępności,systemy monitorujące,rejestr stanu dostepności i zgodności,]
+tags: [narzędzia automatyczne,automatyczna analiza,monitorowanie dostępności,ocenianie dostępności,rejestr stanu dostepności i zgodności,]
+opracowanie: Stefan Wajda
+data_zgloszenia: 13 lipca 2026 r.
+ostatnia_aktualizacja: 13 lipca 2026 r.
+wersja_robocza: true
+
+---
+
+# 1. Cel dokumentu
+
+Dokument określa zasady wykorzystywania narzędzi automatycznych do wykrywania problemów i zmian stanu rozwiązań cyfrowych, wspierania ich oceniania oraz dostarczania informacji potrzebnych do podejmowania, realizowania i weryfikowania decyzji służących zapewnianiu i doskonaleniu dostępności.
+
+Celem automatycznych analiz nie jest samo wykrywanie, liczenie ani raportowanie problemów. Wyniki analiz powinny dostarczać podstaw do ustalenia, co należy naprawić, zmienić, zmodernizować lub poddać dalszej ocenie.
+
+Narzędzia automatyczne mogą zwiększać zdolność organizacji do systematycznego pozyskiwania informacji o stanie rozwiązań cyfrowych. Informacje te powinny być interpretowane, weryfikowane, łączone z informacjami pochodzącymi z innych źródeł i wykorzystywane do:
+
+- rozpoznawania problemów dostępności;
+- oceniania stanu dostępności i zgodności;
+- podejmowania decyzji;
+- planowania i realizowania działań;
+- weryfikowania skuteczności działań;
+- aktualizowania wiedzy o stanie rozwiązania.
+
+Narzędzia automatyczne nie zastępują testów manualnych i funkcjonalnych, ocen eksperckich ani badań z użytkownikami.
+
+---
+
+# 2. Zasady wykorzystywania narzędzi automatycznych
+
+## 2.1. Ukierunkowanie na poprawę dostępności
+
+Automatyczne analizy wykonuje się w celu dostarczenia informacji potrzebnych do zapewniania i doskonalenia dostępności rozwiązania.
+
+Wyniki powinny, na tyle, na ile pozwala zastosowana metoda, umożliwiać ustalenie:
+
+- jaki problem występuje;
+- gdzie i w jakim zakresie występuje;
+- czy jest problemem jednostkowym, powtarzalnym lub systemowym;
+- czy wymaga dalszej oceny;
+- jakie działanie może być potrzebne;
+- w jaki sposób można zweryfikować skuteczność działania.
+
+Raportowanie problemów, utrzymywanie informacji o stanie rozwiązania oraz prowadzenie rejestrów służą podejmowaniu i realizowaniu decyzji, a nie stanowią samodzielnego celu.
+
+## 2.2. Pierwszeństwo automatycznego sprawdzania
+
+Problemy możliwe do wiarygodnego i efektywnego wykrycia automatycznego powinny być identyfikowane za pomocą narzędzi automatycznych, zamiast angażowania pracy eksperckiej do ich ręcznego wyszukiwania.
+
+Jeżeli badane rozwiązanie i cel oceny pozwalają na zastosowanie narzędzi automatycznych, analizę automatyczną przeprowadza się przed rozpoczęciem szczegółowych testów manualnych albo na początku oceny.
+
+Wyniki automatycznej analizy mogą służyć do:
+
+- usunięcia jednoznacznie rozpoznanych problemów;
+- rozpoznania problemów powtarzalnych i systemowych;
+- wskazania obszarów wymagających dalszej oceny;
+- doboru scenariuszy testów;
+- określenia zakresu dalszych badań;
+- efektywnego wykorzystania pracy osób wykonujących testy manualne i funkcjonalne.
+
+## 2.3. Uzupełnianie metod oceniania
+
+Automatyczne analizy obejmują wyłącznie problemy możliwe do rozpoznania za pomocą zastosowanych reguł.
+
+Brak problemów wykrytych automatycznie nie oznacza, że rozwiązanie jest dostępne ani zgodne z wymaganiami.
+
+Automatycznych analiz nie stosuje się jako zamiennika:
+
+- testów manualnych;
+- testów funkcjonalnych;
+- testów z technologiami wspomagającymi;
+- ocen eksperckich;
+- badań z użytkownikami.
+
+Automatyczne analizowanie oraz inne metody oceniania powinny wzajemnie się uzupełniać.
+
+## 2.4. Wykorzystywanie wyników do działania
+
+Wartość automatycznej analizy zależy nie tylko od liczby i trafności wykrywanych problemów, lecz także od możliwości wykorzystania wyników do podejmowania decyzji i realizowania działań.
+
+Wyniki powinny być przedstawiane i porządkowane w sposób umożliwiający ich wykorzystanie przez osoby odpowiedzialne za:
+
+- zarządzanie rozwiązaniem;
+- jego utrzymanie i rozwój;
+- tworzenie i publikowanie treści;
+- zapewnianie jakości;
+- zapewnianie dostępności;
+- podejmowanie decyzji zarządczych.
+
+---
+
+# 3. Rola automatyzacji w obserwowaniu i ocenianiu stanu dostępności
+
+Narzędzia automatyczne są jednym ze źródeł informacji wykorzystywanych w procesie:
+
+> obserwowanie → ocenianie → decyzja → działanie → weryfikacja → aktualizacja wiedzy.
+
+Automatyczne analizy mogą:
+
+- ujawniać nowe problemy;
+- wykrywać zmiany stanu rozwiązania;
+- dostarczać informacji potrzebnych do wykonania scenariuszy testów;
+- wskazywać potrzebę przeprowadzenia oceny doraźnej;
+- wspierać planowanie ocen;
+- dostarczać informacji do podejmowania decyzji;
+- wspierać weryfikowanie skuteczności działań;
+- wykrywać ponowne wystąpienie wcześniej usuniętych problemów.
+
+Wynik wygenerowany przez narzędzie nie powinien być automatycznie utożsamiany z:
+
+- obserwacją zarejestrowaną w Rejestrze Stanu Zgodności i Dostępności;
+- potwierdzoną niezgodnością;
+- wynikiem scenariusza testu;
+- oceną zgodności rozwiązania.
+
+W zależności od rodzaju wyniku i zastosowanej metody potrzebne może być jego zinterpretowanie, zweryfikowanie, połączenie z innymi informacjami albo wykonanie dodatkowych testów.
+
+---
+
+# 4. Sposoby wykorzystywania narzędzi automatycznych
+
+## 4.1. Automatyczne sprawdzanie
+
+Automatyczne sprawdzanie polega na jednorazowym lub doraźnym wykonaniu analizy określonej strony, ekranu, dokumentu, komponentu lub innego obiektu.
+
+Może służyć w szczególności do:
+
+- wstępnego rozpoznania stanu rozwiązania;
+- wsparcia wykonywania oceny;
+- zbadania problemu zgłoszonego przez użytkownika;
+- sprawdzenia zmienionego obiektu;
+- sprawdzenia poprawności wykonanej naprawy.
+
+## 4.2. Automatyczne skanowanie
+
+Automatyczne skanowanie polega na analizowaniu większego zbioru obiektów.
+
+Może służyć w szczególności do:
+
+- rozpoznania skali występowania problemów;
+- identyfikowania problemów powtarzalnych;
+- wykrywania problemów systemowych;
+- ustalania obszarów podwyższonego ryzyka;
+- wyboru obiektów wymagających dalszej oceny;
+- rozpoznawania stanu dużych rozwiązań cyfrowych.
+
+## 4.3. Automatyczne monitorowanie
+
+Automatyczne monitorowanie polega na powtarzaniu analiz rozwiązania oraz utrzymywaniu i porównywaniu wyników w czasie.
+
+Może służyć w szczególności do:
+
+- ciągłego obserwowania stanu rozwiązania;
+- wykrywania nowych problemów;
+- wykrywania zmian stanu;
+- obserwowania trendów;
+- śledzenia skuteczności działań naprawczych;
+- wykrywania regresji;
+- utrzymywania historii wyników.
+
+Granice między automatycznym sprawdzaniem, skanowaniem i monitorowaniem nie zawsze są ostre. Jedno narzędzie może wspierać kilka sposobów wykorzystywania automatyzacji.
+
+---
+
+# 5. Sposoby automatycznego monitorowania
+
+## 5.1. Monitorowanie przez automatyczne skanowanie
+
+System monitorujący może samodzielnie odwiedzać i analizować obiekty rozwiązania cyfrowego.
+
+Systemy oparte na automatycznym skanowaniu mogą:
+
+- analizować dużą liczbę stron;
+- wykonywać analizy według ustalonego harmonogramu;
+- powtarzać analizy w podobnych warunkach;
+- porównywać kolejne wyniki;
+- wykrywać problemy występujące w wielu obiektach.
+
+Zakres obserwacji zależy jednak od zdolności systemu do odnajdywania obiektów i osiągania stanów rozwiązania.
+
+System może nie obejmować między innymi:
+
+- obiektów wymagających uwierzytelnienia;
+- niektórych dynamicznych stanów interfejsu;
+- kolejnych etapów procesów użytkownika;
+- treści dostępnych dopiero po wykonaniu określonych interakcji.
+
+## 5.2. Monitorowanie podczas rzeczywistego korzystania
+
+Niektóre systemy wykonują automatyczne analizy podczas rzeczywistych odwiedzin i interakcji użytkowników z rozwiązaniem.
+
+Analizy mogą wówczas obejmować:
+
+- rzeczywiście odwiedzane obiekty;
+- stany rozwiązania osiągane podczas korzystania;
+- dynamicznie prezentowane treści;
+- różne urządzenia, systemy, przeglądarki i inne środowiska użytkowania.
+
+Ten sposób monitorowania może dostarczać informacji o problemach występujących w rzeczywiście wykorzystywanych częściach rozwiązania i konkretnych środowiskach użytkowników.
+
+Zakres obserwacji zależy jednak od sposobu korzystania z rozwiązania. Obiekty rzadko odwiedzane lub nieodwiedzane mogą pozostać poza analizą.
+
+## 5.3. Łączenie sposobów monitorowania
+
+Organizacja może łączyć różne sposoby automatycznego monitorowania.
+
+Automatyczne skanowanie może zapewniać systematyczne sprawdzanie ustalonego zakresu rozwiązania, natomiast analizy wykonywane podczas rzeczywistego korzystania mogą dostarczać informacji o osiąganych stanach rozwiązania i środowiskach użytkowania.
+
+Oba sposoby monitorowania mogą być uzupełniane przez:
+
+- oceny planowe;
+- oceny doraźne;
+- testy manualne i funkcjonalne;
+- zgłoszenia użytkowników;
+- wyniki odbiorów;
+- informacje o zmianach;
+- inne źródła obserwacji.
+
+---
+
+# 6. Ustalanie zakresu automatycznych analiz
+
+Przed rozpoczęciem automatycznej analizy organizacja powinna ustalić:
+
+- jej cel;
+- rozwiązanie i obiekty objęte analizą;
+- oczekiwany rodzaj informacji;
+- sposób wykorzystania wyników;
+- potrzebę powtarzania analizy;
+- sposób dokumentowania i utrzymywania wyników.
+
+Przy interpretowaniu zakresu automatycznej analizy należy uwzględniać różne rodzaje pokrycia rozwiązania.
+
+## 6.1. Pokrycie strukturalne
+
+Określa, jakie strony, ekrany, dokumenty, komponenty i inne obiekty zostały objęte analizą.
+
+## 6.2. Pokrycie funkcjonalne
+
+Określa, jakie funkcje, procesy użytkownika i stany interfejsu zostały osiągnięte podczas analizy.
+
+## 6.3. Pokrycie użytkowe
+
+Określa, jakie rzeczywiście wykorzystywane części rozwiązania zostały objęte obserwacją.
+
+## 6.4. Pokrycie środowisk użytkowania
+
+Określa, w jakich urządzeniach, systemach, przeglądarkach, konfiguracjach i innych środowiskach wykonano analizy.
+
+## 6.5. Pokrycie wymagań
+
+Określa, jakie wymagania dostępności mogą być sprawdzane za pomocą zastosowanych reguł automatycznych.
+
+Duży zakres automatycznego skanowania nie oznacza dużego zakresu oceny zgodności.
+
+Informacja, że narzędzie przeanalizowało wszystkie lub większość stron rozwiązania, nie oznacza, że oceniono wszystkie istotne funkcje, stany interfejsu, środowiska użytkowania ani wymagania dostępności.
+
+---
+
+# 7. Interpretowanie i porządkowanie wyników
+
+## 7.1. Analizowanie wyników
+
+Wyniki automatycznych analiz powinny być interpretowane odpowiednio do sposobu działania narzędzia, rodzaju zastosowanej reguły oraz celu analizy.
+
+Organizacja powinna rozróżniać:
+
+### Problem potwierdzony
+
+Wynik dostarcza wystarczających podstaw do stwierdzenia występowania problemu.
+
+### Potencjalny problem wymagający weryfikacji
+
+Narzędzie wykryło cechę wskazującą na możliwość występowania problemu, ale jego potwierdzenie wymaga oceny człowieka.
+
+### Informację wspierającą ocenę
+
+Wynik nie przesądza o występowaniu problemu, ale dostarcza informacji przydatnej podczas wykonywania scenariusza testu lub innej analizy.
+
+### Wynik błędny lub nieprzydatny
+
+Wynik jest fałszywym alarmem, wynika z ograniczeń narzędzia albo nie ma znaczenia dla celu prowadzonej analizy.
+
+Klasyfikacje i nazwy wyników stosowane przez konkretne narzędzia mogą różnić się od klasyfikacji przyjętej przez organizację.
+
+## 7.2. Agregowanie wyników
+
+Organizacja nie powinna automatycznie traktować każdego komunikatu narzędzia jako odrębnej obserwacji lub niezgodności.
+
+Wyniki należy analizować pod kątem:
+
+- duplikatów;
+- powtarzalnych wystąpień;
+- wspólnych przyczyn;
+- problemów dotyczących jednego komponentu lub szablonu;
+- problemów systemowych;
+- zmian stanu wcześniej rozpoznanych problemów.
+
+Setki wystąpień tego samego problemu mogą wymagać naprawienia jednego wspólnego komponentu, zmiany szablonu albo poprawienia procesu tworzenia i publikowania treści.
+
+Dlatego wyniki powinny być przekształcane w informacje umożliwiające podjęcie właściwego działania:
+
+> surowe wyniki → grupowanie → analiza → weryfikacja → ustalenie problemu → decyzja → działanie.
+
+---
+
+# 8. Wykorzystywanie wyników do oceniania i aktualizowania wiedzy
+
+Wyniki automatycznych analiz mogą wspierać ocenianie stanu dostępności i zgodności.
+
+Mogą służyć do:
+
+- wykonywania scenariuszy testów;
+- wskazywania scenariuszy wymagających wykonania;
+- dostarczania części materiałów dowodowych;
+- wybierania obiektów do dalszej oceny;
+- rozszerzania badanej próbki;
+- identyfikowania obszarów podwyższonego ryzyka;
+- podejmowania ocen doraźnych;
+- planowania kolejnych ocen.
+
+Automatyczne analizy mogą być wykorzystywane we wszystkich profilach ocen.
+
+W profilu wstępnym mogą służyć przede wszystkim do szybkiego rozpoznania problemów i obszarów ryzyka.
+
+W profilu rozszerzonym mogą wspierać analizowanie większej próbki, rozpoznawanie problemów powtarzalnych i systemowych oraz planowanie dalszego rozszerzania zakresu oceny.
+
+W profilu pogłębionym mogą być wykorzystywane specjalistyczne narzędzia, zaawansowane sposoby automatyzacji oraz wyniki wymagające wiedzy eksperckiej.
+
+Wyniki automatycznych analiz mogą być wykorzystywane do aktualizowania rejestru stanu zgodności i dostępności (RSZiD).
+
+Do RSZiD nie powinny być automatycznie przenoszone wszystkie komunikaty generowane przez narzędzie.
+
+Rejestrowane mogą być w szczególności:
+
+- potwierdzone problemy;
+- istotne obserwacje wymagające dalszej oceny;
+- problemy powtarzalne;
+- problemy systemowe;
+- zmiany stanu wymagające decyzji lub działania.
+
+Pełne raporty i zbiory wyników mogą być przechowywane jako materiały dowodowe.
+
+---
+
+# 9. Wykorzystywanie wyników do podejmowania decyzji i działań
+
+Wyniki automatycznych analiz powinny dostarczać podstaw do podejmowania decyzji służących zapewnianiu i doskonaleniu dostępności rozwiązania.
+
+W zależności od charakteru i znaczenia ustaleń organizacja może zdecydować o:
+
+- naprawieniu pojedynczego problemu;
+- usunięciu wszystkich rozpoznanych wystąpień problemu;
+- naprawieniu wspólnego komponentu lub szablonu;
+- zmianie sposobu tworzenia albo publikowania treści;
+- zmianie procesu utrzymania lub rozwoju rozwiązania;
+- wykonaniu dodatkowych testów;
+- przeprowadzeniu oceny doraźnej;
+- zaangażowaniu specjalistów lub wykonawcy;
+- modernizacji części rozwiązania;
+- przebudowie rozwiązania;
+- uwzględnieniu problemu w planie dalszego doskonalenia dostępności.
+
+Wykrycie problemu nie przesądza o sposobie działania.
+
+Przy podejmowaniu decyzji należy uwzględniać również inne dostępne informacje, w szczególności:
+
+- wpływ problemu na użytkowników;
+- znaczenie obiektu lub procesu;
+- skalę i powtarzalność problemu;
+- wspólną przyczynę wielu wystąpień;
+- ryzyko wystąpienia problemu w innych obiektach;
+- możliwość i koszt naprawy;
+- planowane zmiany i modernizacje rozwiązania.
+
+Wyniki powinny być przedstawiane i utrzymywane w sposób umożliwiający ich wykorzystanie przez osoby podejmujące decyzje oraz osoby odpowiedzialne za wykonanie działań.
+
+---
+
+# 10. Weryfikowanie skuteczności działań
+
+Narzędzia automatyczne mogą wspierać sprawdzanie skuteczności wykonanych działań.
+
+Ponowna analiza może służyć do:
+
+- sprawdzenia, czy wcześniej wykryty problem nadal występuje;
+- wyszukania innych wystąpień tego samego problemu;
+- sprawdzenia skutków zmiany komponentu lub szablonu;
+- wykrywania nowych problemów powstałych wskutek zmiany;
+- wykrywania regresji;
+- obserwowania zmian wyników w czasie.
+
+Brak ponownego wykrycia problemu nie zawsze stanowi wystarczające potwierdzenie skuteczności działania.
+
+Jeżeli charakter problemu tego wymaga, weryfikację należy uzupełnić odpowiednimi testami manualnymi, funkcjonalnymi lub innymi metodami oceny.
+
+Wyniki weryfikacji powinny być wykorzystywane do:
+
+- potwierdzenia skuteczności działania;
+- ponownego otwarcia problemu;
+- podjęcia dodatkowych działań;
+- aktualizacji wiedzy o stanie rozwiązania.
+
+---
+
+# 11. Utrzymywanie, wymiana i integrowanie informacji
+
+## 11.1. Systemy monitorujące jako źródło informacji
+
+Systemy automatycznego monitorowania mogą:
+
+- utrzymywać historię wyników;
+- wykrywać nowe problemy;
+- śledzić zmiany stanu;
+- grupować wystąpienia;
+- przypisywać statusy;
+- wspierać zarządzanie działaniami;
+- dostarczać wskaźników i trendów.
+
+Dzięki tym właściwościom mogą pełnić funkcję technicznego komponentu rejestru stanu zgodności i dostępności.
+
+System monitorujący nie staje się jednak automatycznie pełnym RSZiD.
+
+Wiedza o stanie rozwiązania może pochodzić również z:
+
+- testów manualnych i funkcjonalnych;
+- ocen eksperckich;
+- zgłoszeń użytkowników;
+- badań z użytkownikami;
+- odbiorów;
+- informacji o zmianach;
+- decyzji;
+- działań;
+- materiałów dowodowych.
+
+Organizacja powinna ustalić, w jaki sposób informacje pochodzące z systemów monitorujących są łączone z informacjami z innych źródeł i wykorzystywane w procesie podejmowania decyzji.
+
+## 11.2. Raportowanie, eksportowanie i integrowanie danych
+
+Narzędzia mogą udostępniać wyniki na różne sposoby.
+
+**Raportowanie** polega na przedstawianiu wyników w postaci przeznaczonej przede wszystkim do odczytania przez człowieka.
+
+**Eksportowanie danych** polega na udostępnianiu wyników w ustrukturyzowanej postaci umożliwiającej ich dalsze przetwarzanie.
+
+**Integracja systemów** umożliwia automatyczne przekazywanie, importowanie lub synchronizowanie informacji.
+
+Możliwość wymiany danych pozwala wykorzystywać wyniki analiz poza systemem, który je wygenerował.
+
+Wyniki mogą być:
+
+- filtrowane;
+- agregowane;
+- porównywane;
+- łączone z wynikami innych narzędzi;
+- wiązane z obiektami rozwiązania;
+- wykorzystywane do aktualizowania RSZiD;
+- przekazywane do systemów zarządzania zadaniami i działaniami.
+
+Przy wymianie danych należy, na tyle, na ile jest to możliwe, zachowywać informacje pozwalające ustalić:
+
+- przedmiot wyniku;
+- źródło;
+- czas wykonania analizy;
+- zastosowane narzędzie i regułę;
+- kontekst i środowisko analizy;
+- powiązanie wyniku z wcześniejszymi informacjami o stanie rozwiązania.
+
+## 11.3. Wykorzystywanie wskaźników i trendów
+
+Systemy monitorujące mogą generować:
+
+- wyniki punktowe;
+- odsetki;
+- liczby wykrytych problemów;
+- liczby obiektów z problemami;
+- trendy;
+- porównania.
+
+Wskaźniki te mogą służyć do obserwowania zmian i porównywania wyników uzyskanych przy zastosowaniu tej samej metody.
+
+Nie powinny być traktowane jako samodzielna miara dostępności lub zgodności rozwiązania.
+
+Na porównywalność wyników mogą wpływać zmiany:
+
+- zakresu analizy;
+- zestawu reguł;
+- wersji narzędzia;
+- struktury rozwiązania;
+- sposobu korzystania z rozwiązania;
+- środowisk wykonywania analiz.
+
+---
+
+# 12. Dobór i rozwijanie sposobu wykorzystania narzędzi
+
+Organizacja powinna dobierać narzędzia i sposoby ich wykorzystywania odpowiednio do decyzji i działań, które chce wspierać za pomocą automatyzacji.
+
+Przed wyborem narzędzia należy ustalić:
+
+- jakie informacje są potrzebne;
+- jakie rozwiązania i obiekty powinny być analizowane;
+- jakie problemy organizacja chce wykrywać;
+- jak często potrzebne są analizy;
+- czy potrzebne jest utrzymywanie historii wyników;
+- czy potrzebne jest obserwowanie rzeczywistego korzystania i środowisk użytkowników;
+- w jaki sposób wyniki będą wykorzystywane podczas oceniania;
+- w jaki sposób wyniki będą przekazywane osobom odpowiedzialnym za decyzje i działania;
+- czy dane powinny być wymieniane z innymi systemami.
+
+Przy ocenie przydatności narzędzia należy uwzględniać w szczególności:
+
+- zakres wykonywanych analiz;
+- obsługiwane rodzaje rozwiązań i technologii;
+- sposób pozyskiwania informacji;
+- możliwy zakres pokrycia rozwiązania;
+- możliwość wykonywania analiz w różnych środowiskach;
+- możliwość powtarzania analiz;
+- utrzymywanie historii wyników;
+- grupowanie problemów;
+- wspieranie zarządzania działaniami;
+- możliwość eksportowania danych;
+- dostępność API i innych mechanizmów integracji;
+- zakres metadanych przekazywanych wraz z wynikami;
+- możliwość współpracy z RSZiD i innymi systemami organizacji;
+- dostępność narzędzia dla osób, które mają się nim posługiwać.
+
+Systemy automatycznego monitorowania mogą być rozwijane od narzędzi wykrywających problemy w kierunku platform wspierających zarządzanie stanem dostępności.
+
+Mogą być wzbogacane o funkcje:
+
+- gromadzenia wyników z różnych źródeł;
+- dokumentowania obserwacji;
+- przechowywania wyników testów manualnych;
+- wiązania informacji z materiałami dowodowymi;
+- oceniania wpływu problemów;
+- dokumentowania decyzji;
+- planowania i śledzenia działań;
+- przypisywania odpowiedzialności;
+- weryfikowania skuteczności działań.
+
+Systemy takie mogą ewoluować w kierunku Monitorów Dostępności Cyfrowej.
+
+Możliwy jest również odwrotny kierunek rozwoju: Monitor Dostępności Cyfrowej może integrować się z zewnętrznymi narzędziami automatycznymi albo zostać wyposażony we własne funkcje automatycznej analizy.
+
+Niezależnie od zastosowanego rozwiązania technicznego celem jest stworzenie mechanizmu, który wspiera organizację w:
+
+> wykrywaniu problemów i zmian → ocenianiu ich znaczenia → podejmowaniu decyzji → realizowaniu działań → weryfikowaniu rezultatów → doskonaleniu dostępności rozwiązania.
+
+---
+
+# 13. Ograniczenia i najczęstsze błędy
+
+Automatyczne analizy mają ograniczony zakres i wymagają świadomego wykorzystywania.
+
+Należy unikać w szczególności:
+
+- utożsamiania braku wykrytych problemów z dostępnością rozwiązania;
+- traktowania wyników automatycznych jako pełnej oceny zgodności;
+- zastępowania testów manualnych i funkcjonalnych automatyczną analizą;
+- bezkrytycznego przyjmowania komunikatów narzędzia;
+- rejestrowania każdego komunikatu jako odrębnej niezgodności;
+- braku agregowania problemów powtarzalnych i systemowych;
+- wykonywania analiz bez określonego celu;
+- gromadzenia raportów bez podejmowania decyzji i działań;
+- niewykorzystywania wyników do planowania dalszych ocen;
+- nieustalania faktycznego zakresu monitorowania;
+- utożsamiania liczby przeanalizowanych obiektów z zakresem oceny zgodności;
+- porównywania wyników uzyskanych różnymi metodami lub w nieporównywalnych warunkach;
+- traktowania wyników punktowych jako miary dostępności rozwiązania;
+- angażowania pracy eksperckiej do ręcznego wyszukiwania problemów, które mogą być efektywnie wykrywane automatycznie;
+- ograniczania oceniania do problemów możliwych do wykrycia automatycznie;
+- pozostawiania wyników w systemie monitorującym bez powiązania ich z procesem oceniania, podejmowania decyzji i realizowania działań.
+
+Największą wartość narzędzia automatyczne zapewniają wtedy, gdy są częścią trwałego procesu, w którym informacje o problemach i zmianach stanu rozwiązania są wykorzystywane do podejmowania działań, sprawdzania ich skuteczności i systematycznego doskonalenia dostępności.

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/wykorzystywanie-narzedzi-automatycznych-do-obserwowania-i-oceniania-stanu-dostepnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/wykorzystywanie-narzedzi-automatycznych-do-obserwowania-i-oceniania-stanu-dostepnosci.md
@@ -114,7 +114,7 @@ Automatyczne analizy mogą:
 
 Wynik wygenerowany przez narzędzie nie powinien być automatycznie utożsamiany z:
 
-- obserwacją zarejestrowaną w Rejestrze Stanu Zgodności i Dostępności;
+- obserwacją zarejestrowaną w rejestrze stanu zgodności i dostępności;
 - potwierdzoną niezgodnością;
 - wynikiem scenariusza testu;
 - oceną zgodności rozwiązania.
@@ -545,9 +545,9 @@ Mogą być wzbogacane o funkcje:
 - przypisywania odpowiedzialności;
 - weryfikowania skuteczności działań.
 
-Systemy takie mogą ewoluować w kierunku Monitorów Dostępności Cyfrowej.
+Systemy takie mogą ewoluować w kierunku monitorów dostępności cyfrowej.
 
-Możliwy jest również odwrotny kierunek rozwoju: Monitor Dostępności Cyfrowej może integrować się z zewnętrznymi narzędziami automatycznymi albo zostać wyposażony we własne funkcje automatycznej analizy.
+Możliwy jest również odwrotny kierunek rozwoju: monitor dostępności cyfrowej może integrować się z zewnętrznymi narzędziami automatycznymi albo zostać wyposażony we własne funkcje automatycznej analizy.
 
 Niezależnie od zastosowanego rozwiązania technicznego celem jest stworzenie mechanizmu, który wspiera organizację w:
 

--- a/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/zasady-prowadzenia-rejestru-stanu-dostepnosci-i-zgodnosci.md
+++ b/documentation/docs/cykltik/obserwowanie-i-ocenianie-dostepnosci-i-zgodnosc/zasady-prowadzenia-rejestru-stanu-dostepnosci-i-zgodnosci.md
@@ -1,0 +1,282 @@
+---
+id: zasady-prowadzenia-rejestru-stanu-dostepnosci-i-zgodnosci
+title: Zasady prowadzenia rejestru stanu dostępności i zgodności
+description: Zasady organizowania, aktualizowania, utrzymywania i wykorzystywania wiedzy o stanie dostępności i zgodności rozwiązań cyfrowych.
+sidebar_label: Zasady prowadzenia rejestru
+sidebar_position: 4
+keywords: [dostępność cyfrowa, stan dostępności, stan zgodności, rejestr dostępności, obserwacja, ocena zgodności, materiały dowodowe, zakres rozpoznania]
+tags: [dostępność cyfrowa, stan dostępności, stan zgodności, rejestr dostępności, obserwacja, ocena zgodności, materiały dowodowe, zakres rozpoznania]
+opracowanie: Stefan Wajda
+data_zgloszenia: 12 lipca 2026 r.
+ostatnia_aktualizacja: 12 lipca 2026 r.
+wersja_robocza: true
+---
+
+
+## Cel dokumentu
+
+Dokument określa zasady organizowania, aktualizowania, utrzymywania i wykorzystywania wiedzy o stanie dostępności i zgodności rozwiązania cyfrowego w rejestrze stanu dostępności i zgodności, w tym zakres dokumentowanych informacji, relacje między nimi oraz zasady zachowania aktualności i historii wiedzy.
+
+## 1. Rola rejestru
+
+Rejestr stanu dostępności i zgodności jest uporządkowanym zasobem wiedzy o stanie dostępności i zgodności konkretnego rozwiązania cyfrowego.
+
+Służy do:
+
+- gromadzenia informacji uzyskiwanych podczas obserwowania i oceniania stanu;
+- łączenia informacji pochodzących z różnych źródeł i ocen;
+- utrzymywania wiedzy o obecnym stanie rozwiązania;
+- zachowania historii wcześniejszych ustaleń;
+- ustalania zakresu rozpoznania stanu;
+- udostępniania informacji potrzebnych w innych procesach systemu zapewniania dostępności cyfrowej.
+
+Rejestr nie jest raportem z pojedynczej oceny ani zbiorem kolejnych niezależnych raportów.
+
+Jest rozwijanym zasobem wiedzy aktualizowanym przez cały okres użytkowania rozwiązania cyfrowego.
+
+## 2. Dwa podstawowe rodzaje wiedzy
+
+Rejestr powinien umożliwiać ustalenie:
+
+1. **co wiadomo o stanie dostępności i zgodności rozwiązania;**
+2. **jaki jest zakres rozpoznania tego stanu.**
+
+### 2.1. Wiedza o stanie
+
+Wiedza o stanie opisuje stwierdzony stan rozwiązania i należących do niego obiektów.
+
+Pozwala ustalić w szczególności:
+
+- jakie stany zostały zaobserwowane;
+- jakich obiektów i cech dotyczą;
+- kiedy zostały stwierdzone;
+- na jakiej podstawie dokonano ustaleń;
+- jak oceniono zgodność stwierdzonego stanu;
+- jaki wpływ na użytkowników został rozpoznany;
+- które informacje stanowią podstawę opisu obecnego stanu.
+
+### 2.2. Zakres rozpoznania stanu
+
+Zakres rozpoznania pozwala ustalić, jakiej części rozwiązania i mających zastosowanie wymagań dotyczy posiadana wiedza.
+
+Obejmuje informacje o:
+
+- wymaganiach objętych oceną;
+- obszarach funkcjonalnych, funkcjach i procesach użytkownika objętych oceną;
+- stronach, ekranach, dokumentach, komponentach i innych obiektach tworzących badaną próbę;
+- wymaganiach i częściach rozwiązania dotychczas nieocenionych;
+- informacjach wymagających aktualizacji, uzupełnienia albo weryfikacji.
+
+Rozróżnienie wiedzy o stanie i zakresu jego rozpoznania zapobiega utożsamianiu braku stwierdzonych problemów z potwierdzeniem zgodności rozwiązania.
+
+Szczegółowe zasady analizowania zakresu rozpoznania określa załącznik „Analiza zakresu rozpoznania stanu dostępności i zgodności”.
+
+## 3. Model informacji rejestru
+
+Rejestr prowadzi się dla konkretnego rozwiązania cyfrowego, na przykład strony internetowej, serwisu internetowego, aplikacji mobilnej, systemu teleinformatycznego albo usługi publicznej realizowanej drogą elektroniczną.
+
+Podstawę rejestru tworzą powiązane informacje o:
+
+- rozwiązaniu cyfrowym;
+- obiektach;
+- obserwacjach;
+- źródłach informacji;
+- materiałach dowodowych;
+- ocenach zgodności;
+- ocenach wpływu;
+- przeprowadzonych ocenach;
+- zakresie ocen;
+- aktualności wiedzy;
+- zakresie rozpoznania;
+- decyzjach;
+- działaniach.
+
+Informacje te nie powinny być sprowadzane do jednej tabeli wyników testów albo listy stwierdzonych niezgodności.
+
+Rejestr powinien umożliwiać odrębne dokumentowanie poszczególnych informacji oraz zachowanie relacji między nimi.
+
+## 4. Rozwiązanie cyfrowe i jego obiekty
+
+Rejestr powinien umożliwiać identyfikację rozwiązania cyfrowego, którego dotyczy.
+
+Dla rozwiązania dokumentuje się co najmniej:
+
+- identyfikator;
+- nazwę;
+- rodzaj rozwiązania.
+
+W rejestrze identyfikuje się również obiekty, których dotyczą obserwacje i oceny.
+
+Obiektami mogą być w szczególności:
+
+- obszary funkcjonalne;
+- procesy użytkownika;
+- strony;
+- ekrany;
+- widoki;
+- komponenty;
+- elementy;
+- treści;
+- dokumenty;
+- inne części rozwiązania podlegające obserwowaniu i ocenianiu.
+
+Sposób identyfikacji obiektów powinien umożliwiać jednoznaczne ustalenie przedmiotu obserwacji i ocen oraz zachowanie powiązań między informacjami dotyczącymi tego samego obiektu.
+
+## 5. Obserwacje
+
+Podstawową jednostką wiedzy o stanie dokumentowanej w rejestrze jest obserwacja.
+
+Obserwacja jest udokumentowaną informacją o stwierdzonym stanie cechy określonego obiektu.
+
+Dla obserwacji dokumentuje się co najmniej:
+
+- identyfikator;
+- obiekt, którego dotyczy;
+- cechę obiektu;
+- opis stwierdzonego stanu;
+- datę dokonania obserwacji;
+- źródło informacji;
+- podstawę dokonanego ustalenia;
+- status aktualności jako podstawy opisu obecnego stanu.
+
+Obserwacja może być powiązana w szczególności z:
+
+- materiałami dowodowymi;
+- ocenami zgodności;
+- ocenami wpływu;
+- oceną planową lub doraźną, podczas której uzyskano informację;
+- innymi obserwacjami;
+- decyzjami;
+- działaniami.
+
+Zasady wyodrębniania obserwacji i przekształcania wyników w wiedzę określa załącznik „Przetwarzanie wyników obserwowania i oceniania stanu dostępności i zgodności”.
+
+## 6. Źródła informacji i materiały dowodowe
+
+Rejestr powinien umożliwiać ustalenie źródła każdej obserwacji oraz jej powiązanie z materiałami dowodowymi stanowiącymi podstawę dokonanego ustalenia.
+
+Jedna obserwacja może być powiązana z wieloma materiałami dowodowymi, a jeden materiał dowodowy może stanowić podstawę wielu obserwacji.
+
+Rejestr nie musi bezpośrednio przechowywać materiałów dowodowych. Powinien umożliwiać ich jednoznaczną identyfikację i odnalezienie.
+
+
+## 7. Oceny zgodności i wpływu
+
+Rejestr powinien umożliwiać odrębne dokumentowanie stwierdzonego stanu oraz powiązanych z nim ocen zgodności i wpływu na użytkowników.
+
+Dla oceny zgodności dokumentuje się co najmniej wymaganie, oceniany obiekt lub zakres, wynik i datę oceny oraz jej powiązanie z obserwacjami i materiałami dowodowymi stanowiącymi podstawę oceny.
+
+Dla oceny wpływu dokumentuje się co najmniej wynik i datę oceny oraz jej powiązanie z obserwacją, której dotyczy.
+
+Szczegółowe zasady dokonywania ocen zgodności i wpływu określa załącznik „Przetwarzanie wyników obserwowania i oceniania stanu dostępności i zgodności”.
+
+## 8. Dokumentowanie ocen i ich zakresu
+
+Rejestr powinien umożliwiać ustalenie, podczas jakiej oceny uzyskano określone informacje.
+
+Dla przeprowadzonej oceny dokumentuje się co najmniej:
+
+- identyfikator;
+- rodzaj oceny: planowa albo doraźna;
+- cel;
+- datę lub okres przeprowadzenia;
+- wykonawcę oceny;
+- zakres wymagań;
+- zakres funkcjonalny;
+- zakres badanej próby;
+- zastosowane scenariusze testów i inne metody.
+
+W przypadku oceny planowej dokumentuje się również zastosowany profil.
+
+Informacje o zakresie oceny powinny umożliwiać prawidłową interpretację jej wyników oraz ustalenie, jaki zakres wiedzy uzyskano, potwierdzono, zaktualizowano albo zweryfikowano.
+
+## 9. Aktualność wiedzy
+
+Rejestr powinien umożliwiać ustalenie, które informacje mogą stanowić podstawę opisu obecnego stanu rozwiązania.
+
+Informacje o stanie oznacza się jako aktualne, wymagające weryfikacji albo nieaktualne.
+
+Aktualność informacji ustala się z uwzględnieniem zmian rozwiązania i nowych informacji o jego stanie. Sam upływ czasu nie powoduje automatycznie utraty aktualności informacji.
+
+## 10. Zachowanie historii wiedzy
+
+Rejestr powinien umożliwiać odtworzenie zmian wiedzy o stanie rozwiązania w czasie.
+
+Historycznej obserwacji nie nadpisuje się nowym stanem. Jeżeli uzyskane informacje wskazują zmianę stanu, dokumentuje się nowe ustalenie i zachowuje jego powiązanie z wcześniejszą wiedzą.
+
+Rejestr powinien umożliwiać ustalenie, jaki stan i na jakiej podstawie stwierdzono wcześniej, jakie informacje potwierdziły, uzupełniły albo zmieniły wcześniejszą wiedzę oraz jakie oceny, decyzje, działania i materiały dowodowe były z nią powiązane.
+
+Korekta błędnego wpisu nie powinna usuwać informacji potrzebnych do ustalenia, kto, kiedy i dlaczego dokonał zmiany.
+
+
+## 11. Powiązanie informacji
+
+Wartość rejestru wynika nie tylko z gromadzenia poszczególnych informacji, ale przede wszystkim z zachowania relacji między nimi.
+
+Rejestr powinien umożliwiać prześledzenie odpowiednio do potrzeb między innymi ciągu:
+
+**rozwiązanie → obiekt → obserwacja → materiał dowodowy → ocena → decyzja → działanie → weryfikacja → aktualizacja wiedzy**
+
+Nie każda informacja musi być powiązana ze wszystkimi elementami tego ciągu.
+
+Rejestr powinien jednak umożliwiać zachowanie relacji potrzebnych do ustalenia:
+
+- czego dotyczy informacja;
+- skąd pochodzi;
+- na jakiej podstawie dokonano ustalenia;
+- jak została oceniona;
+- czy pozostaje aktualna;
+- jakie decyzje i działania były z nią związane;
+- jakie późniejsze informacje wpłynęły na wiedzę o stanie.
+
+Informacje o stanie mogą być powiązane z informacjami dokumentowanymi w innych rejestrach i zasobach informacji SZDC.
+
+## 12. Wykorzystywanie informacji i raportowanie
+
+Informacje zgromadzone w rejestrze są wykorzystywane w procesach systemu zapewniania dostępności cyfrowej, w szczególności do analizowania stanu i zakresu jego rozpoznania, planowania ocen, podejmowania decyzji i działań oraz weryfikowania ich skuteczności.
+
+Na podstawie informacji zgromadzonych w rejestrze można przygotowywać raporty i zestawienia odpowiednie do celu ich wykorzystania.
+
+Raport jest prezentacją wiedzy zgromadzonej w rejestrze. Nie zastępuje rejestru, a jego utworzenie nie zamyka procesu rozwijania i aktualizowania wiedzy o stanie.
+
+## 14. Forma prowadzenia rejestru
+
+Rejestr może być prowadzony za pomocą dedykowanej aplikacji, bazy danych, systemu zarządzania sprawami lub zadaniami, arkusza kalkulacyjnego albo innego odpowiedniego narzędzia.
+
+Narzędzie powinno umożliwiać dokumentowanie wymaganych informacji, zachowanie relacji między nimi i historii zmian oraz wyszukiwanie i wykorzystywanie zgromadzonej wiedzy.
+
+Wybór narzędzia powinien być dostosowany do wielkości i złożoności rozwiązania, zakresu dokumentowanych informacji oraz potrzeb organizacji.
+
+## 16. Odpowiedzialność i jakość danych
+
+Organizacja określa odpowiedzialność za prowadzenie rejestru, dokumentowanie i aktualizowanie informacji, weryfikowanie jakości danych oraz zapewnienie ich integralności i zachowania historii zmian.
+
+Uprawnienia do tworzenia, uzupełniania, korygowania i zatwierdzania informacji dostosowuje się do ról uczestniczących w obserwowaniu, ocenianiu i wykorzystywaniu wiedzy o stanie.
+
+Organizacja zapewnia jednoznaczność, aktualność i odpowiedni zakres informacji oraz możliwość ustalenia ich przedmiotu, źródła, podstawy i historii zmian.
+
+
+
+<!--
+
+## 14. Minimalny zakres informacji w rejestrze
+
+Rejestr powinien umożliwiać dokumentowanie co najmniej następujących informacji:
+
+| Grupa informacji    | Minimalny zakres                                                      |
+| ------------------- | --------------------------------------------------------------------- |
+| Rozwiązanie cyfrowe | identyfikator, nazwa, rodzaj                                          |
+| Obiekt              | identyfikator, rodzaj, nazwa lub opis                                 |
+| Obserwacja          | identyfikator, obiekt, cecha, opis stwierdzonego stanu, data, źródło  |
+| Materiał dowodowy   | identyfikator lub wskazanie materiału stanowiącego podstawę ustalenia |
+| Ocena zgodności     | wymaganie, zakres, wynik, data                                        |
+| Ocena wpływu        | wynik i data, jeżeli wpływ został oceniony                            |
+| Ocena               | identyfikator, rodzaj, cel, data lub okres, wykonawca                 |
+| Profil              | profil oceny planowej, jeżeli dotyczy                                 |
+| Zakres oceny        | oceniane wymagania, zakres funkcjonalny, zakres badanej próby         |
+| Metoda              | zastosowany scenariusz testu lub inna metoda uzyskania informacji     |
+| Aktualność          | status aktualności informacji jako podstawy opisu obecnego stanu      |
+| Powiązania          | powiązane obserwacje, oceny, materiały dowodowe, decyzje i działania  |
+
+Organizacja może rozszerzyć zakres informacji odpowiednio do swoich potrzeb, sposobu organizacji procesów i stosowanych narzędzi.
+-->


### PR DESCRIPTION
[Zobacz podgląd dokumentów](https://deploy-preview-253--siec-dostepnosci-cyfrowej.netlify.app/docs/category/obserwowanie-i-ocenianie-stanu-dost%C4%99pno%C5%9Bci-i-zgodno%C5%9Bci)

Projekt zastępuje zgłoszoną wcześniej propozycję zalecenia #199 oraz zaaprobowanego już przez Sieć zalecenia [Procedura oceny dostępności](https://siec-dostepnosci-cyfrowej.github.io/sdc/docs/category/procedura-oceny-dost%C4%99pno%C5%9Bci)

Przyczyny rezygnacji z rozwijania projektu #199 oraz propozycji wycofania zalecenia Procedura oceny dostępności zostały wyjaśnione dokładnie  w dołączonych do pakietu dokumentach roboczych Uzasadnienie 1 i Uzasadnienie 2.